### PR TITLE
feat(response): Add cookies support

### DIFF
--- a/examples/only_get.py
+++ b/examples/only_get.py
@@ -3,11 +3,12 @@ import rnet
 from rnet import Method, Impersonate
 
 async def main():
-    resp = await rnet.get("https://httpbin.org/range/15")
+    resp = await rnet.get("https://www.google.com/")
     print("Status Code: ", resp.status_code)
     print("Version: ", resp.version)
     print("Response URL: ", resp.url)
     print("Headers: ", resp.headers.to_dict())
+    print("Cookies: ", resp.cookies)
     print("Content-Length: ", resp.content_length)
     print("Encoding: ", resp.encoding)
     print("Remote Address: ", resp.remote_addr)
@@ -15,8 +16,8 @@ async def main():
     # Close the response connection
     # await resp.close()
 
-    text_content = await resp.text()
-    print("Text: ", text_content)
+    # text_content = await resp.text()
+    # print("Text: ", text_content)
 
     # text_with_charset = await resp.text_with_charset(encoding="utf-8")
     # print("Text with charset: ", text_with_charset)


### PR DESCRIPTION
This pull request includes changes to the `examples/only_get.py` and `src/response.rs` files. The most important changes involve updating the response handling in the `Response` struct and adding new functionalities.

### Response handling improvements:

* [`src/response.rs`](diffhunk://#diff-6f9f8f882acd334c5bf0b598b309afef5f90f63d20b4cc6c26751d66bcb1dba6R276-R288): Added a new `inner` method to provide access to the inner `rquest::Response` wrapped in an `Arc`. This method helps in accessing the original response object directly.
* [`src/response.rs`](diffhunk://#diff-6f9f8f882acd334c5bf0b598b309afef5f90f63d20b4cc6c26751d66bcb1dba6L81-R83): Modified the `headers` getter method to return a `PyResult<HeaderMap>` instead of `HeaderMap`, utilizing the new `inner` method.
* [`src/response.rs`](diffhunk://#diff-6f9f8f882acd334c5bf0b598b309afef5f90f63d20b4cc6c26751d66bcb1dba6L99-R137): Updated the `encoding` getter method to use the new `inner` method and return a `PyResult<&str>`.

### New functionalities:

* [`src/response.rs`](diffhunk://#diff-6f9f8f882acd334c5bf0b598b309afef5f90f63d20b4cc6c26751d66bcb1dba6L99-R137): Added a new `cookies` getter method to return the cookies of the response as a Python dictionary.

### Minor changes:

* [`examples/only_get.py`](diffhunk://#diff-c53c7d5fccaa03de07a279aeb8ad7d059f99549215365605227c1b94c0354c64L6-R20): Updated the URL in the `rnet.get` call and added printing of cookies in the response.
* [`src/response.rs`](diffhunk://#diff-6f9f8f882acd334c5bf0b598b309afef5f90f63d20b4cc6c26751d66bcb1dba6L9-R9): Included `types::PyDict` in the `pyo3` imports.