### PR TITLE
perf(resp): Improve drop response overhead

### DIFF
--- a/examples/only_get.py
+++ b/examples/only_get.py
@@ -6,7 +6,7 @@ from rnet import Method, Impersonate, Version
 async def main():
     resp = await rnet.get(
         "https://tls.peet.ws/api/all",
-        impersonate=Impersonate.Chrome104,
+        impersonate=Impersonate.Chrome100,
         user_agent="Mozilla/5.0",
         version=Version.HTTP_2,
         timeout=10,
@@ -40,7 +40,7 @@ async def main():
     # print("JSON String Pretty: ", json_value)
 
     # Close the response connection
-    # await resp.close()
+    # resp.close()
 
 
 if __name__ == "__main__":

--- a/examples/only_req.py
+++ b/examples/only_req.py
@@ -15,7 +15,7 @@ async def main():
     print("Remote Address: ", resp.remote_addr)
 
     # Close the response connection
-    # await resp.close()
+    # resp.close()
 
     # text_content = await resp.text()
     # print("Text: ", text_content)

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -256,12 +256,8 @@ impl Response {
     /// # Arguments
     ///
     /// * `py` - The Python interpreter.
-    pub fn close<'rt>(&mut self, py: Python<'rt>) -> PyResult<Bound<'rt, PyAny>> {
-        let resp = self.into_inner()?;
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            drop(resp);
-            Ok(())
-        })
+    pub fn close(&mut self) {
+        let _ = self.into_inner().map(drop);
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `examples/only_get.py`, `examples/only_req.py`, and `src/resp.rs` files. The most important changes involve modifying the `impersonate` parameter, updating the response connection closing method, and simplifying the `close` method in the `Response` implementation.

### Changes to `examples/only_get.py`:
* Updated the `impersonate` parameter from `Impersonate.Chrome104` to `Impersonate.Chrome100`.
* Modified the commented-out response connection closing method from `await resp.close()` to `resp.close()`.

### Changes to `examples/only_req.py`:
* Modified the commented-out response connection closing method from `await resp.close()` to `resp.close()`.

### Changes to `src/resp.rs`:
* Simplified the `close` method in the `Response` implementation by removing the asynchronous handling and directly dropping the response.