### PR TITLE
feat(resp): Allows thread-safe operation of Response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 mime = "0.3.17"
 indexmap = { version = "2.7.0", features = ["serde"] }
+arc-swap = "1.7.1"
 rquest = { version = "2.0", features = ["full"] }


### PR DESCRIPTION
This pull request introduces several changes to the `Response` struct and its implementation in the `src/resp.rs` file to improve its handling of internal state and simplify the code. The most important changes include adding the `arc-swap` dependency, updating the `Response` struct to use `ArcSwapOption`, and modifying various methods to work with the new internal structure.

Dependency Addition:
* Added `arc-swap = "1.7.1"` to `Cargo.toml` to enable atomic swapping of `Arc` pointers.

Struct and Field Updates:
* Updated the `Response` struct to include a `url` field and replaced the `response` field with an `ArcSwapOption<rquest::Response>`.

Method Modifications:
* Modified the `impl From<rquest::Response> for Response` to initialize the new fields and use `ArcSwapOption::from_pointee` for the `response` field.
* Simplified getter methods such as `url`, `headers`, and `cookies` to directly access the new fields instead of the inner response. [[1]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L42-R48) [[2]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L76-R82) [[3]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L123-R134)
* Updated various methods to work with the new `ArcSwapOption` structure, including `encoding`, `text`, `json`, `bytes`, `stream`, and `close`. [[1]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L95-R101) [[2]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L142-R146) [[3]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L181-R185) [[4]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L232-R236) [[5]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L249-R254) [[6]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L259-L277)

Helper Method Removal:
* Removed the `inner` helper method since it is no longer necessary with the new structure. [[1]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L259-L277) [[2]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L289-R284)