### PR TITLE
feat(client): Add cookie store option

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -111,6 +111,9 @@ impl Client {
         // Referer options.
         apply_option!(apply_if_some, builder, params.referer, referer);
 
+        // Cookie store options.
+        apply_option!(apply_if_some, builder, params.cookie_store, cookie_store);
+
         // Timeout options.
         apply_option!(
             apply_transformed_option,

--- a/src/param/client.rs
+++ b/src/param/client.rs
@@ -53,6 +53,10 @@ pub struct ClientParams {
     #[pyo3(get)]
     pub referer: Option<bool>,
 
+    /// Whether to use cookie store.
+    #[pyo3(get)]
+    pub cookie_store: Option<bool>,
+
     // ========= Timeout options =========
     /// The timeout to use for the request. (in seconds)
     #[pyo3(get)]
@@ -164,6 +168,7 @@ impl<'py> FromPyObject<'py> for ClientParams {
         extract_option!(ob, params, default_headers);
         extract_option!(ob, params, headers_order);
         extract_option!(ob, params, referer);
+        extract_option!(ob, params, cookie_store);
 
         extract_option!(ob, params, timeout);
         extract_option!(ob, params, connect_timeout);


### PR DESCRIPTION
This pull request introduces changes to the `Client` and `ClientParams` structures to add support for cookie store options. The most important changes include adding the `cookie_store` option to the `ClientParams` structure and ensuring it is properly applied in the `Client` implementation.

Enhancements to `Client` and `ClientParams`:

* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R114-R116): Added the application of the `cookie_store` option in the `Client` implementation.
* [`src/param/client.rs`](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R56-R59): Added the `cookie_store` field to the `ClientParams` structure with appropriate documentation and getter method.
* [`src/param/client.rs`](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R171): Updated the `FromPyObject` implementation for `ClientParams` to extract the `cookie_store` option.