### PR TITLE
build: Fix manylinux build

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 <target>"
+  echo "Usage: $0 <target> [manylinux]"
   exit 1
 fi
 
-BASH_IMAGE="ghcr.io/0x676e67/rust-musl-cross"
 TARGET=$1
+MANYLINUX=$2
+
+BASH_IMAGE="ghcr.io/0x676e67/rust-musl-cross"
 VOLUME_MAPPING="-v $(pwd):/home/rust/src"
 MATURIN_CMD="maturin build --release --out dist --find-interpreter"
 
@@ -25,6 +27,11 @@ case $TARGET in
     exit 1
     ;;
 esac
+
+if [ "$MANYLINUX" == "manylinux" ]; then
+  echo "Building for manylinux..."
+  MATURIN_CMD="maturin build --release --target $TARGET --out dist --manylinux"
+fi
 
 echo "Building for $TARGET..."
 docker run --rm $VOLUME_MAPPING $BASH_IMAGE:$TARGET /bin/bash -c "$MATURIN_CMD"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build wheels
         run: 
-          bash .github/build.sh ${{ matrix.platform.target }}
+          bash .github/build.sh ${{ matrix.platform.target }} manylinux
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
+    environment: ManyLinux
     strategy:
       matrix:
         platform:
@@ -42,6 +43,7 @@ jobs:
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
+    environment: MuslLinux
     strategy:
       matrix:
         platform:
@@ -66,6 +68,7 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
+    environment: Windows
     strategy:
       matrix:
         platform:
@@ -101,6 +104,7 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
+    environment: MacOS
     strategy:
       matrix:
         platform:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,7 +9,7 @@ jobs:
   style:
     name: Style
     runs-on: ubuntu-latest
-    environment: Linux
+    environment: Style
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Python HTTP Client with Black Magic, powered by FFI from [rquest](https://github
 
 ## Wheels
 
-* Linux (Musl/GNU): `x86_64`,`aarch64`,`armv7`,`i686`
+* Linux (Musl/GNU-GLIBC-2.34): `x86_64`,`aarch64`,`armv7`,`i686`
 
 * macOS: `x86_64`,`aarch64`
 

--- a/examples/client.py
+++ b/examples/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import rnet
 from rnet import Impersonate, Client
 
 


### PR DESCRIPTION
This pull request includes changes to support building manylinux wheels, updates to the README for clarity, and minor code cleanup in an example file. The most important changes are summarized below:

### Support for manylinux wheels:

* [`.github/build.sh`](diffhunk://#diff-01777b8211405b5ca734f053a69b200b01d7d3b1fb10fbdb337cff18417438f5L4-R11): Added an optional `manylinux` argument to the build script and modified the `MATURIN_CMD` to support building manylinux wheels when this argument is provided. [[1]](diffhunk://#diff-01777b8211405b5ca734f053a69b200b01d7d3b1fb10fbdb337cff18417438f5L4-R11) [[2]](diffhunk://#diff-01777b8211405b5ca734f053a69b200b01d7d3b1fb10fbdb337cff18417438f5R31-R35)
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL36-R36): Updated the CI workflow to pass the `manylinux` argument to the build script.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26): Updated the description of Linux wheel compatibility to specify GNU-GLIBC-2.34.

### Code cleanup:

* [`examples/client.py`](diffhunk://#diff-11c528f6f45c94140909cbbc80d8934cd6617f9000e65253e70784bc250a694fL2): Removed an unnecessary import statement.