### PR TITLE
feat(resp): Wrapper easy-to-use `StatusCode`

### DIFF
--- a/rnet.pyi
+++ b/rnet.pyi
@@ -547,7 +547,7 @@ class Response:
     """
     url: builtins.str
     ok: builtins.bool
-    status_code: builtins.int
+    status_code: StatusCode
     version: Version
     headers: HeaderMap
     content_length: builtins.int
@@ -665,6 +665,56 @@ class SocketAddr:
         r"""
         Returns the socket address as a string.
         """
+        ...
+
+
+class StatusCode:
+    r"""
+    HTTP status code.
+    """
+    def as_int(self) -> builtins.int:
+        r"""
+        Return the status code as an integer.
+        """
+        ...
+
+    def is_informational(self) -> builtins.bool:
+        r"""
+        Check if status is within 100-199.
+        """
+        ...
+
+    def is_success(self) -> builtins.bool:
+        r"""
+        Check if status is within 200-299.
+        """
+        ...
+
+    def is_redirection(self) -> builtins.bool:
+        r"""
+        Check if status is within 300-399.
+        """
+        ...
+
+    def is_client_error(self) -> builtins.bool:
+        r"""
+        Check if status is within 400-499.
+        """
+        ...
+
+    def is_server_error(self) -> builtins.bool:
+        r"""
+        Check if status is within 500-599.
+        """
+        ...
+
+    def __str__(self) -> builtins.str:
+        r"""
+        Returns a str representation of the `StatusCode`
+        """
+        ...
+
+    def __repr__(self) -> builtins.str:
         ...
 
 

--- a/rnet.pyi
+++ b/rnet.pyi
@@ -547,7 +547,7 @@ class Response:
     """
     url: builtins.str
     ok: builtins.bool
-    status_code: typing.Any
+    status_code: builtins.int
     version: Version
     headers: HeaderMap
     content_length: builtins.int

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@ use client::Client;
 use param::{ClientParams, RequestParams};
 use pyo3::prelude::*;
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
-use types::{HeaderMap, Impersonate, Method, Proxy, SocketAddr, Version};
+use resp::Response;
+use types::{HeaderMap, Impersonate, Method, Proxy, SocketAddr, StatusCode, Version};
 
 #[macro_export]
 macro_rules! define_constants {
@@ -265,7 +266,8 @@ fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Proxy>()?;
     m.add_class::<ClientParams>()?;
     m.add_class::<RequestParams>()?;
-    m.add_class::<resp::Response>()?;
+    m.add_class::<StatusCode>()?;
+    m.add_class::<Response>()?;
     m.add_class::<Client>()?;
     m.add_function(wrap_pyfunction!(request, m)?)?;
     m.add_function(wrap_pyfunction!(get, m)?)?;

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -1,12 +1,12 @@
 use crate::{
     error::{memory_error, wrap_rquest_error, wrap_serde_error},
-    types::{HeaderMap, Json, SocketAddr, Version},
+    types::{HeaderMap, Json, SocketAddr, StatusCode, Version},
 };
 use arc_swap::ArcSwapOption;
 use mime::Mime;
 use pyo3::{exceptions::PyStopAsyncIteration, prelude::*, types::PyDict, IntoPyObjectExt};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
-use rquest::{header, StatusCode, Url};
+use rquest::{header, Url};
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -52,7 +52,7 @@ impl From<rquest::Response> for Response {
         Response {
             url: response.url().clone(),
             version: Version::from(response.version()),
-            status_code: response.status(),
+            status_code: StatusCode::from(response.status()),
             remote_addr: response.remote_addr(),
             content_length: response.content_length(),
             headers: HeaderMap::from(std::mem::take(response.headers_mut())),
@@ -90,8 +90,8 @@ impl Response {
     ///
     /// A Python object representing the HTTP status code.
     #[getter]
-    pub fn status_code(&self) -> u16 {
-        self.status_code.as_u16()
+    pub fn status_code(&self) -> StatusCode {
+        self.status_code
     }
 
     /// Returns the HTTP version of the response.

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -90,10 +90,8 @@ impl Response {
     ///
     /// A Python object representing the HTTP status code.
     #[getter]
-    pub fn status_code<'rt>(&'rt self, py: Python<'rt>) -> PyResult<Bound<'rt, PyAny>> {
-        let http_module = py.import("http")?;
-        let http_enum = http_module.getattr("HTTPStatus")?;
-        http_enum.call1((self.status_code.as_u16(),))
+    pub fn status_code(&self) -> u16 {
+        self.status_code.as_u16()
     }
 
     /// Returns the HTTP version of the response.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,9 +4,10 @@ mod ipaddr;
 mod json;
 mod method;
 mod proxy;
+mod status_code;
 mod version;
 
 pub use self::{
     headers::HeaderMap, impersonate::Impersonate, ipaddr::SocketAddr, json::Json, method::Method,
-    proxy::Proxy, version::Version,
+    proxy::Proxy, version::Version, status_code::StatusCode,
 };

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,5 +9,5 @@ mod version;
 
 pub use self::{
     headers::HeaderMap, impersonate::Impersonate, ipaddr::SocketAddr, json::Json, method::Method,
-    proxy::Proxy, version::Version, status_code::StatusCode,
+    proxy::Proxy, status_code::StatusCode, version::Version,
 };

--- a/src/types/status_code.rs
+++ b/src/types/status_code.rs
@@ -1,0 +1,63 @@
+use pyo3::prelude::*;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
+
+/// HTTP status code.
+#[gen_stub_pyclass]
+#[pyclass(eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct StatusCode(rquest::StatusCode);
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl StatusCode {
+    /// Return the status code as an integer.
+    #[inline]
+    pub const fn as_int(&self) -> u16 {
+        self.0.as_u16()
+    }
+
+    /// Check if status is within 100-199.
+    #[inline]
+    pub fn is_informational(&self) -> bool {
+        self.0.is_informational()
+    }
+
+    /// Check if status is within 200-299.
+    #[inline]
+    pub fn is_success(&self) -> bool {
+        self.0.is_success()
+    }
+
+    /// Check if status is within 300-399.
+    #[inline]
+    pub fn is_redirection(&self) -> bool {
+        self.0.is_redirection()
+    }
+
+    /// Check if status is within 400-499.
+    #[inline]
+    pub fn is_client_error(&self) -> bool {
+        self.0.is_client_error()
+    }
+
+    /// Check if status is within 500-599.
+    #[inline]
+    pub fn is_server_error(&self) -> bool {
+        self.0.is_server_error()
+    }
+
+    /// Returns a str representation of the `StatusCode`
+    fn __str__(&self) -> &str {
+        self.0.as_str()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("StatusCode({})", self.0))
+    }
+}
+
+impl From<rquest::StatusCode> for StatusCode {
+    fn from(status_code: rquest::StatusCode) -> Self {
+        Self(status_code)
+    }
+}


### PR DESCRIPTION
This pull request includes changes to the `Response` class in the `rnet.pyi` file and the `Response` implementation in the `src/resp.rs` file. The main focus of these changes is to update the type of the `status_code` attribute and simplify its getter method.

Type update:

* [`rnet.pyi`](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eL550-R550): Changed the type of `status_code` from `typing.Any` to `builtins.int`.

Getter method simplification:

* [`src/resp.rs`](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L93-R94): Simplified the `status_code` getter method by returning the status code directly as a `u16` instead of creating a Python object.