### PR TITLE
feat: Shortcut method request support redirect

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -603,6 +603,16 @@ async fn execute_request(
         |v: Version| v.into_inner()
     );
 
+    // Allow redirects options.
+    apply_option!(
+        apply_option_or_default_with_value,
+        builder,
+        params.allow_redirects,
+        redirect,
+        false,
+        Policy::default()
+    );
+
     // Timeout options.
     apply_option!(
         apply_transformed_option,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,21 +11,6 @@ use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use resp::Response;
 use types::{HeaderMap, Impersonate, Method, Proxy, SocketAddr, StatusCode, Version};
 
-#[macro_export]
-macro_rules! define_constants {
-    ($type:tt, $inner_type:ty, $($name:ident),*) => {
-        #[allow(non_upper_case_globals)]
-        #[gen_stub_pymethods]
-        #[pymethods]
-        impl $type {
-            $(
-                #[classattr]
-                pub const $name: $type = $type(<$inner_type>::$name);
-            )*
-        }
-    };
-}
-
 type Result<T> = std::result::Result<T, PyErr>;
 
 /// Shortcut method to quickly make a `GET` request.

--- a/src/param/req.rs
+++ b/src/param/req.rs
@@ -62,6 +62,9 @@ pub struct RequestParams {
     /// The headers to use for the request.
     pub headers: Option<IndexMap<String, String>>,
 
+    /// Whether to allow redirects.
+    pub allow_redirects: Option<bool>,
+
     /// The authentication to use for the request.
     #[pyo3(get)]
     pub auth: Option<String>,
@@ -107,6 +110,7 @@ impl<'py> FromPyObject<'py> for RequestParams {
 
         extract_option!(ob, params, version);
         extract_option!(ob, params, headers);
+        extract_option!(ob, params, allow_redirects);
         extract_option!(ob, params, auth);
         extract_option!(ob, params, bearer_auth);
         extract_option!(ob, params, basic_auth);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,3 +11,18 @@ pub use self::{
     headers::HeaderMap, impersonate::Impersonate, ipaddr::SocketAddr, json::Json, method::Method,
     proxy::Proxy, status_code::StatusCode, version::Version,
 };
+
+#[macro_export]
+macro_rules! define_constants {
+    ($type:tt, $inner_type:ty, $($name:ident),*) => {
+        #[allow(non_upper_case_globals)]
+        #[gen_stub_pymethods]
+        #[pymethods]
+        impl $type {
+            $(
+                #[classattr]
+                pub const $name: $type = $type(<$inner_type>::$name);
+            )*
+        }
+    };
+}


### PR DESCRIPTION
This pull request includes several changes to improve the handling of request parameters and macro definitions in the Rust codebase. The most important changes include adding support for redirect options, moving a macro definition, and updating the `RequestParams` struct and its implementation.

Improvements to request parameters:

* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R606-R615): Added support for redirect options in the `execute_request` function by applying the `allow_redirects` parameter.
* [`src/param/req.rs`](diffhunk://#diff-586db287f66766708a28ea51faf15b6701148458f588aac618223bc2f457fe92R65-R67): Updated the `RequestParams` struct to include an `allow_redirects` field and modified the `FromPyObject` implementation to extract this option. [[1]](diffhunk://#diff-586db287f66766708a28ea51faf15b6701148458f588aac618223bc2f457fe92R65-R67) [[2]](diffhunk://#diff-586db287f66766708a28ea51faf15b6701148458f588aac618223bc2f457fe92R113)

Macro definition changes:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L14-L28): Removed the `define_constants` macro definition.
* [`src/types/mod.rs`](diffhunk://#diff-44bee847315d06d50bad561b0284381c81b52274429ff45ccec047d25f8ce45dR14-R28): Added the `define_constants` macro definition to this module.