### PR TITLE
feat(resp): Expose `Streamer` as public API

### DIFF
--- a/rnet.pyi
+++ b/rnet.pyi
@@ -628,7 +628,7 @@ class Response:
         """
         ...
 
-    def stream(self) -> typing.Any:
+    def stream(self) -> Streamer:
         r"""
         Returns the stream content of the response.
         

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,3 @@
-/*
- *   Copyright (c) 2025
- *   All rights reserved.
- */
 use crate::{
     error::{wrap_invali_header_name_error, wrap_rquest_error},
     param::{ClientParams, RequestParams},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use client::Client;
 use param::{ClientParams, RequestParams};
 use pyo3::prelude::*;
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
-use resp::Response;
+use resp::{Response, Streamer};
 use types::{HeaderMap, Impersonate, Method, Proxy, SocketAddr, StatusCode, Version};
 
 type Result<T> = std::result::Result<T, PyErr>;
@@ -253,6 +253,7 @@ fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RequestParams>()?;
     m.add_class::<StatusCode>()?;
     m.add_class::<Response>()?;
+    m.add_class::<Streamer>()?;
     m.add_class::<Client>()?;
     m.add_function(wrap_pyfunction!(request, m)?)?;
     m.add_function(wrap_pyfunction!(get, m)?)?;

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -70,6 +70,7 @@ impl Response {
     ///
     /// A string representing the URL of the response.
     #[getter]
+    #[inline(always)]
     pub fn url(&self) -> &str {
         self.url.as_str()
     }
@@ -80,6 +81,7 @@ impl Response {
     ///
     /// A boolean indicating whether the response is successful.
     #[getter]
+    #[inline(always)]
     pub fn ok(&self) -> bool {
         self.status_code.is_success()
     }
@@ -90,6 +92,7 @@ impl Response {
     ///
     /// A Python object representing the HTTP status code.
     #[getter]
+    #[inline(always)]
     pub fn status_code(&self) -> StatusCode {
         self.status_code
     }
@@ -100,6 +103,7 @@ impl Response {
     ///
     /// A `Version` object representing the HTTP version of the response.
     #[getter]
+    #[inline(always)]
     pub fn version(&self) -> Version {
         self.version
     }
@@ -110,6 +114,7 @@ impl Response {
     ///
     /// A `HeaderMap` object representing the headers of the response.
     #[getter]
+    #[inline(always)]
     pub fn headers(&self) -> HeaderMap {
         self.headers.clone()
     }
@@ -120,6 +125,7 @@ impl Response {
     ///
     /// An integer representing the content length of the response.
     #[getter]
+    #[inline(always)]
     pub fn content_length(&self) -> u64 {
         self.content_length.unwrap_or_default()
     }
@@ -130,6 +136,7 @@ impl Response {
     ///
     /// An `IpAddr` object representing the remote address of the response.
     #[getter]
+    #[inline(always)]
     pub fn remote_addr(&self) -> Option<SocketAddr> {
         self.remote_addr.map(SocketAddr::from)
     }
@@ -284,9 +291,8 @@ impl Response {
     /// # Returns
     ///
     /// A Python object representing the stream content of the response.
-    pub fn stream<'rt>(&self, py: Python<'rt>) -> PyResult<Bound<'rt, PyAny>> {
-        let streamer = self.into_inner().map(Streamer::new)?;
-        streamer.into_bound_py_any(py)
+    pub fn stream(&self) -> PyResult<Streamer> {
+        self.into_inner().map(Streamer::new)
     }
 
     /// Closes the response connection.
@@ -349,7 +355,7 @@ impl Response {
 /// ```
 #[gen_stub_pyclass]
 #[pyclass]
-struct Streamer(Arc<Mutex<rquest::Response>>);
+pub struct Streamer(Arc<Mutex<rquest::Response>>);
 
 impl Streamer {
     /// Creates a new `Streamer` instance.


### PR DESCRIPTION
This pull request includes several changes to the `Response` class and related files to improve type safety and performance. The most important changes include modifying the `stream` method to return a `Streamer` type, adding the `Streamer` class to the module, and optimizing getter methods for the `Response` class.

Changes to type safety and method signatures:

* [`rnet.pyi`](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eL631-R631): Modified the `stream` method in the `Response` class to return a `Streamer` type instead of `typing.Any`.
* [`src/resp.rs`](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16L287-R295): Updated the `stream` method in the `Response` class to return a `Streamer` instance.

Module and class additions:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R256): Added the `Streamer` class to the module.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L11-R11): Updated the import statement to include the `Streamer` class.

Performance optimizations:

* [`src/resp.rs`](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R73): Added `#[inline(always)]` attribute to several getter methods in the `Response` class for performance improvement. [[1]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R73) [[2]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R84) [[3]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R95) [[4]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R106) [[5]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R117) [[6]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R128) [[7]](diffhunk://#diff-9a3d8ee28d27cfa8b2299e506a0a95487f26e9e67b282b93f7cf4987f559cf16R139)