### PR TITLE
perf: Initialize and optimize Python module without requiring GIL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ fn request(
     Client::default().request(py, method, url, kwds)
 }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Method>()?;
     m.add_class::<Version>()?;


### PR DESCRIPTION
This pull request includes a small change to the `src/lib.rs` file. The change modifies the `#[pymodule]` attribute to specify that the Global Interpreter Lock (GIL) is not used.

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L258-R258): Modified the `#[pymodule]` attribute to `#[pymodule(gil_used = false)]` to indicate that the GIL is not used.