### PR TITLE
perf(resp): Reduce the range of GIL locks

### DIFF
--- a/src/resp.rs
+++ b/src/resp.rs
@@ -3,8 +3,9 @@ use crate::{
     types::{HeaderMap, Json, SocketAddr, StatusCode, Version},
 };
 use arc_swap::ArcSwapOption;
+use indexmap::IndexMap;
 use mime::Mime;
-use pyo3::{exceptions::PyStopAsyncIteration, prelude::*, types::PyDict, IntoPyObjectExt};
+use pyo3::{exceptions::PyStopAsyncIteration, prelude::*, IntoPyObjectExt};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use rquest::{header, TlsInfo, Url};
 use serde_json::Value;
@@ -163,40 +164,19 @@ impl Response {
         Ok(encoding)
     }
 
-    /// Returns the cookies of the response.
-    ///
-    /// # Returns
-    ///
-    /// A Python dictionary representing the cookies of the response.
-    #[getter]
-    pub fn cookies<'rt>(&'rt self, py: Python<'rt>) -> PyResult<Bound<'rt, PyDict>> {
-        let resp_ref = self.response.load();
-        let resp = resp_ref.as_ref().ok_or_else(memory_error)?;
-        let py_dict = PyDict::new(py);
-        resp.cookies()
-            .try_for_each(|cookie| py_dict.set_item(cookie.name(), cookie.value()))?;
-        Ok(py_dict)
-    }
-
     /// Returns the TLS peer certificate of the response.
     ///
     /// # Returns
     ///
     /// A Python object representing the TLS peer certificate of the response.
-    pub fn peer_certificate(&self) -> PyResult<Option<PyObject>> {
-        if let Some(resp) = self.response.load().as_ref() {
-            if let Some(val) = resp.extensions().get::<TlsInfo>() {
-                if let Some(peer_cert_der) = val.peer_certificate() {
-                    return Python::with_gil(|py| {
-                        Ok(Some(peer_cert_der.into_bound_py_any(py)?.unbind()))
-                    });
-                }
-            }
-
-            Ok(None)
-        } else {
-            Err(memory_error())
+    pub fn peer_certificate(&self) -> PyResult<Option<Vec<u8>>> {
+        let resp_ref = self.response.load();
+        let resp = resp_ref.as_ref().ok_or_else(memory_error)?;
+        if let Some(val) = resp.extensions().get::<TlsInfo>() {
+            return Ok(val.peer_certificate().map(ToOwned::to_owned));
         }
+
+        Ok(None)
     }
 
     /// Returns the text content of the response.
@@ -297,6 +277,25 @@ impl Response {
     /// Closes the response connection.
     pub fn close(&self) {
         let _ = self.into_inner().map(drop);
+    }
+}
+
+#[pymethods]
+impl Response {
+    /// Returns the cookies of the response.
+    ///
+    /// # Returns
+    ///
+    /// A Python dictionary representing the cookies of the response.
+    #[getter]
+    pub fn cookies(&self) -> PyResult<IndexMap<String, String>> {
+        let resp_ref = self.response.load();
+        let resp = resp_ref.as_ref().ok_or_else(memory_error)?;
+        let mut py_dict = IndexMap::new();
+        resp.cookies().for_each(|cookie| {
+            py_dict.insert(cookie.name().to_owned(), cookie.value().to_owned());
+        });
+        Ok(py_dict)
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `src/resp.rs` file, focusing on improving the handling of response cookies and TLS peer certificates. The most important changes include replacing the `PyDict` with `IndexMap` for cookies, modifying the `peer_certificate` method to return a `Vec<u8>`, and updating the imports to include `IndexMap` and `TlsInfo`.

### Improvements to response handling:

* Replaced the `PyDict` with `IndexMap` for the `cookies` method to improve the handling of response cookies.
* Modified the `peer_certificate` method to return a `Vec<u8>` instead of a Python object, simplifying the retrieval of the TLS peer certificate.

### Updates to imports:

* Added `indexmap::IndexMap` to the imports to support the new `cookies` method implementation.
* Added `rquest::TlsInfo` to the imports to support the updated `peer_certificate` method.