### PR TITLE
feat: Add base url for client

### DIFF
--- a/examples/base_url.py
+++ b/examples/base_url.py
@@ -1,0 +1,26 @@
+import asyncio
+from rnet import Impersonate, Client
+
+
+async def main():
+    client = Client(
+        base_url="https://httpbin.org",
+        impersonate=Impersonate.Firefox135,
+        user_agent="rnet",
+    )
+    resp = await client.get("/stream/20")
+    print("Status Code: ", resp.status_code)
+    print("Version: ", resp.version)
+    print("Response URL: ", resp.url)
+    print("Headers: ", resp.headers.to_dict())
+    print("Content-Length: ", resp.content_length)
+    print("Encoding: ", resp.encoding)
+    print("Remote Address: ", resp.remote_addr)
+    streamer = resp.stream()
+    async for chunk in streamer:
+        print("Chunk: ", chunk)
+        await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/rnet.pyi
+++ b/rnet.pyi
@@ -275,6 +275,32 @@ class Client:
     def websocket(self, url:builtins.str, **kwds) -> typing.Any:
         r"""
         Sends a WebSocket request.
+        
+        # Arguments
+        
+        * `url` - The URL to send the WebSocket request to.
+        * `**kwds` - Additional WebSocket request parameters.
+        
+        # Returns
+        
+        A `WebSocket` object representing the WebSocket connection.
+        
+        # Examples
+        
+        ```python
+        import rnet
+        import asyncio
+        
+        async def main():
+            client = rnet.Client()
+            ws = await client.websocket("wss://echo.websocket.org")
+            await ws.send(rnet.Message.from_text("Hello, WebSocket!"))
+            message = await ws.recv()
+            print("Received:", message.data)
+            await ws.close()
+        
+        asyncio.run(main())
+        ```
         """
         ...
 
@@ -312,6 +338,7 @@ class ClientParams:
     impersonate_os: typing.Optional[ImpersonateOS]
     impersonate_skip_http2: typing.Optional[builtins.bool]
     impersonate_skip_headers: typing.Optional[builtins.bool]
+    base_url: typing.Optional[builtins.str]
     user_agent: typing.Optional[builtins.str]
     headers_order: typing.Optional[builtins.list[builtins.str]]
     referer: typing.Optional[builtins.bool]

--- a/src/param/client.rs
+++ b/src/param/client.rs
@@ -50,6 +50,10 @@ pub struct ClientParams {
     #[pyo3(get)]
     pub impersonate_skip_headers: Option<bool>,
 
+    /// The base URL to use for the request.
+    #[pyo3(get)]
+    pub base_url: Option<String>,
+
     /// The user agent to use for the request.
     #[pyo3(get)]
     pub user_agent: Option<String>,
@@ -183,6 +187,7 @@ impl<'py> FromPyObject<'py> for ClientParams {
         extract_option!(ob, params, impersonate_skip_http2);
         extract_option!(ob, params, impersonate_skip_headers);
 
+        extract_option!(ob, params, base_url);
         extract_option!(ob, params, user_agent);
         extract_option!(ob, params, default_headers);
         extract_option!(ob, params, headers_order);


### PR DESCRIPTION
This pull request includes several changes to add support for a base URL parameter in the `Client` class, enhance the WebSocket documentation, and update the related Rust structures. The most important changes include adding the `base_url` parameter, updating the `Client` class, and adding an example script demonstrating the new functionality.

### Support for Base URL Parameter:

* [`rnet.pyi`](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eR341): Added `base_url` as an optional string parameter to the `ClientParams` class.
* [`src/param/client.rs`](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R53-R56): Added `base_url` field to the `ClientParams` struct and updated the `FromPyObject` implementation to extract this new parameter. [[1]](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R53-R56) [[2]](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R190)

### Enhancements to WebSocket Documentation:

* [`rnet.pyi`](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eR278-R303): Enhanced the `websocket` method documentation in the `Client` class to include arguments, return values, and examples.

### Example Script:

* [`examples/base_url.py`](diffhunk://#diff-9fd8d790806803de7402a440ff698e9f76b5880781e36a1dd92080e8ee1b8d7cR1-R26): Added a new example script demonstrating how to use the `base_url` parameter with the `Client` class and perform a streaming request.