### PR TITLE
feat(client): Optionally enable asynchronous DNS resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,14 @@ doctest = false
 
 [dependencies]
 tokio = { version = "1.0", features = ["sync"] }
-pyo3 = { version = "0.23.0", features = ["anyhow", "indexmap", "multiple-pymethods", "abi3-py39", "generate-import-lib", "experimental-inspect"] }
+pyo3 = { version = "0.23.0", features = [
+    "anyhow",
+    "indexmap",
+    "multiple-pymethods",
+    "abi3-py39",
+    "generate-import-lib",
+    "experimental-inspect",
+] }
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
 pyo3-stub-gen = "0.7.0"
 anyhow = "1.0"
@@ -27,11 +34,14 @@ indexmap = { version = "2.7.0", features = ["serde"] }
 cookie = "0.18.0"
 arc-swap = "1.7.1"
 url = "2.5"
-rquest = { version = "2.1.5", features = ["full", "websocket"] }
+rquest = { version = "2.1.5", features = ["full", "websocket", "hickory-dns"] }
 futures-util = { version = "0.3.0", default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = { package = "tikv-jemallocator", version = "0.6", features = ["disable_initial_exec_tls", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { package = "tikv-jemallocator", version = "0.6", features = [
+    "disable_initial_exec_tls",
+    "unprefixed_malloc_on_supported_platforms",
+] }
 
 [profile.release]
 lto = true

--- a/examples/client.py
+++ b/examples/client.py
@@ -6,6 +6,7 @@ async def main():
     client = Client(
         impersonate=Impersonate.Firefox133,
         user_agent="rnet",
+        async_dns=True,
     )
     resp = await client.get("https://httpbin.org/stream/20")
     print("Status Code: ", resp.status_code)

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,0 +1,48 @@
+use crate::error::DNSResolverError;
+use rquest::dns::{HickoryDnsResolver, LookupIpStrategy};
+use std::sync::{Arc, OnceLock};
+
+/// Initializes and returns a DNS resolver with the specified strategy.
+///
+/// This function initializes a global DNS resolver using the provided lookup IP strategy.
+/// If the DNS resolver has already been initialized, it returns the existing instance.
+///
+/// # Arguments
+///
+/// * `strategy` - An optional `LookupIpStrategy` to use for the DNS resolver.
+///
+/// # Returns
+///
+/// A `Result` containing an `Arc` to the `HickoryDnsResolver` instance, or an error if initialization fails.
+///
+/// # Errors
+///
+/// This function returns an error if the DNS resolver fails to initialize.
+///
+/// # Examples
+///
+/// ```rust
+/// use rnet::dns::get_or_try_init;
+/// use rquest::dns::LookupIpStrategy;
+///
+/// let resolver = get_or_try_init(LookupIpStrategy::default()).unwrap();
+/// ```
+pub fn get_or_try_init<S>(strategy: S) -> crate::Result<Arc<HickoryDnsResolver>>
+where
+    S: Into<Option<LookupIpStrategy>>,
+{
+    static DNS_RESOLVER: OnceLock<Result<Arc<HickoryDnsResolver>, &'static str>> = OnceLock::new();
+
+    DNS_RESOLVER
+        .get_or_init(move || {
+            HickoryDnsResolver::new(strategy.into())
+                .map(Arc::new)
+                .map_err(|err| {
+                    eprintln!("failed to initialize the DNS resolver: {}", err);
+                    "failed to initialize the DNS resolver"
+                })
+        })
+        .as_ref()
+        .map(Arc::clone)
+        .map_err(DNSResolverError::new_err)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ Potential solutions:
 "#;
 
 create_exception!(exceptions, BorrowingError, PyRuntimeError);
+create_exception!(exceptions, DNSResolverError, PyRuntimeError);
 
 create_exception!(exceptions, BaseError, PyException);
 create_exception!(exceptions, BodyError, BaseError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod client;
+mod dns;
 mod error;
 mod param;
 mod response;

--- a/src/param/client.rs
+++ b/src/param/client.rs
@@ -76,6 +76,10 @@ pub struct ClientParams {
     #[pyo3(get)]
     pub cookie_store: Option<bool>,
 
+    /// Whether to use async DNS resolver.
+    #[pyo3(get)]
+    pub async_dns: Option<bool>,
+
     // ========= Timeout options =========
     /// The timeout to use for the request. (in seconds)
     #[pyo3(get)]
@@ -234,6 +238,7 @@ impl<'py> FromPyObject<'py> for ClientParams {
         extract_option!(ob, params, referer);
         extract_option!(ob, params, allow_redirects);
         extract_option!(ob, params, cookie_store);
+        extract_option!(ob, params, async_dns);
 
         extract_option!(ob, params, timeout);
         extract_option!(ob, params, connect_timeout);


### PR DESCRIPTION
This pull request introduces several important changes to the `rnet` project, focusing on the addition of an asynchronous DNS resolver and improvements to the existing codebase. The most significant changes include modifications to the `Cargo.toml` dependencies, updates to the `Client` struct to support async DNS, and the addition of a new `dns` module.

### Client Enhancements:
* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R2): Imported the `dns` module and added async DNS resolver initialization in the `Client` struct. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R2) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R16) [[3]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L469-R471) [[4]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R539-R544)
* [`examples/client.py`](diffhunk://#diff-11c528f6f45c94140909cbbc80d8934cd6617f9000e65253e70784bc250a694fR9): Enabled `async_dns` in the `Client` initialization.

### New DNS Module:
* [`src/dns.rs`](diffhunk://#diff-59889a794dcd5497d370e57f0ff9c047cba4738d11974377dc610c6b063011ebR1-R48): Added a new module to handle DNS resolution with a function to initialize a global DNS resolver using the `HickoryDnsResolver` and `LookupIpStrategy`.

### Error Handling:
* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR22): Introduced a new `DNSResolverError` exception to handle DNS resolver initialization errors.

### Parameter Updates:
* [`src/param/client.rs`](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R79-R82): Updated `ClientParams` to include the `async_dns` option and modified the `FromPyObject` implementation to extract this new option. [[1]](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R79-R82) [[2]](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R241)

### Module Integration:
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R2): Integrated the new `dns` module.