### PR TITLE
feat: Added bridge from Rust to Python logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ name = "rnet"
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
+[features]
+logging = ["dep:pyo3-log", "dep:log"]
+
 [dependencies]
 tokio = { version = "1.0", features = ["sync"] }
 pyo3 = { version = "0.23.0", features = [
@@ -25,9 +28,9 @@ pyo3 = { version = "0.23.0", features = [
     "experimental-inspect",
 ] }
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
-pyo3-log = "0.12.1"
+pyo3-log = { version = "0.12.1", optional = true }
 pyo3-stub-gen = "0.7.0"
-log = "0.4.25"
+log = { version = "0.4.25", optional = true }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ pyo3 = { version = "0.23.0", features = [
     "experimental-inspect",
 ] }
 pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
+pyo3-log = "0.12.1"
 pyo3-stub-gen = "0.7.0"
+log = "0.4.25"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > 🚀 Help me work seamlessly with open source sharing by [sponsoring me on GitHub](https://github.com/0x676e67/0x676e67/blob/main/SPONSOR.md)
 
-Asynchronous Python HTTP client with Black Magic, powered by FFI from [rquest](https://github.com/0x676e67/rquest). This library can mimic the TLS and HTTP2 configurations of popular browsers like Chrome, Safari, Firefox, and OkHttp.
+An asynchronous Python HTTP client with Black Magic, powered by FFI from [rquest](https://github.com/0x676e67/rquest), capable of mimicking `TLS` and `HTTP2` configurations of popular browsers like `Chrome`, `Safari`, `Firefox`, and `OkHttp`.
 
 ## Features
 

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -1,0 +1,49 @@
+import asyncio
+import logging
+import colorlog
+from rnet import Impersonate, Client
+
+
+formatter = colorlog.ColoredFormatter(
+    "%(log_color)s%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s",
+    datefmt=None,
+    reset=True,
+    log_colors={
+        'DEBUG': 'cyan',
+        'INFO': 'green',
+        'WARNING': 'yellow',
+        'ERROR': 'red',
+        'CRITICAL': 'red,bg_white',
+    },
+    secondary_log_colors={},
+    style='%'
+)
+
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logger = colorlog.getLogger()
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
+
+async def main():
+    client = Client(
+        impersonate=Impersonate.Firefox133,
+        user_agent="rnet",
+        async_dns=True,
+    )
+    resp = await client.get("https://httpbin.org/stream/20")
+    print("Status Code: ", resp.status_code)
+    print("Version: ", resp.version)
+    print("Response URL: ", resp.url)
+    print("Headers: ", resp.headers.to_dict())
+    print("Content-Length: ", resp.content_length)
+    print("Encoding: ", resp.encoding)
+    print("Remote Address: ", resp.remote_addr)
+    streamer = resp.stream()
+    async for chunk in streamer:
+        print("Chunk: ", chunk)
+        await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -38,7 +38,7 @@ where
             HickoryDnsResolver::new(strategy.into())
                 .map(Arc::new)
                 .map_err(|err| {
-                    eprintln!("failed to initialize the DNS resolver: {}", err);
+                    log::error!("failed to initialize the DNS resolver: {}", err);
                     "failed to initialize the DNS resolver"
                 })
         })

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -38,7 +38,14 @@ where
             HickoryDnsResolver::new(strategy.into())
                 .map(Arc::new)
                 .map_err(|err| {
-                    log::error!("failed to initialize the DNS resolver: {}", err);
+                    #[cfg(feature = "logging")]
+                    {
+                        log::error!("failed to initialize the DNS resolver: {}", err);
+                    }
+                    #[cfg(not(feature = "logging"))]
+                    {
+                        eprintln!("failed to initialize the DNS resolver: {}", err);
+                    }
                     "failed to initialize the DNS resolver"
                 })
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,10 @@ mod response;
 mod types;
 
 use client::Client;
+use log::LevelFilter;
 use param::{ClientParams, RequestParams, UpdateClientParams, WebSocketParams};
 use pyo3::prelude::*;
+use pyo3_log::{Caching, Logger};
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use response::{Message, Response, Streamer, WebSocket};
 use types::{
@@ -281,7 +283,13 @@ fn websocket(
 #[pymodule(gil_used = false)]
 fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // A good place to install the Rust -> Python logger.
-    pyo3_log::init();
+    let handle = Logger::new(m.py(), Caching::LoggersAndLevels)?
+        .filter(LevelFilter::Trace)
+        .install()
+        .expect("Someone installed a logger before rnet.");
+
+    // Some time in the future when logging changes, reset the caches:
+    handle.reset();
 
     m.add_class::<Method>()?;
     m.add_class::<Version>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,9 @@ fn websocket(
 
 #[pymodule(gil_used = false)]
 fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // A good place to install the Rust -> Python logger.
+    pyo3_log::init();
+
     m.add_class::<Method>()?;
     m.add_class::<Version>()?;
     m.add_class::<HeaderMap>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@ mod response;
 mod types;
 
 use client::Client;
+#[cfg(feature = "logging")]
 use log::LevelFilter;
 use param::{ClientParams, RequestParams, UpdateClientParams, WebSocketParams};
 use pyo3::prelude::*;
+#[cfg(feature = "logging")]
 use pyo3_log::{Caching, Logger};
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use response::{Message, Response, Streamer, WebSocket};
@@ -283,13 +285,16 @@ fn websocket(
 #[pymodule(gil_used = false)]
 fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // A good place to install the Rust -> Python logger.
-    let handle = Logger::new(m.py(), Caching::LoggersAndLevels)?
-        .filter(LevelFilter::Trace)
-        .install()
-        .expect("Someone installed a logger before rnet.");
+    #[cfg(feature = "logging")]
+    {
+        let handle = Logger::new(m.py(), Caching::LoggersAndLevels)?
+            .filter(LevelFilter::Trace)
+            .install()
+            .expect("Someone installed a logger before rnet.");
 
-    // Some time in the future when logging changes, reset the caches:
-    handle.reset();
+        // Some time in the future when logging changes, reset the caches:
+        handle.reset();
+    }
 
     m.add_class::<Method>()?;
     m.add_class::<Version>()?;


### PR DESCRIPTION
This pull request introduces several significant changes to the `rnet` project, including the addition of logging features, updates to dependencies, and enhancements to the documentation and examples. The most important changes are outlined below:

### Logging Features:
* Added a new `[features]` section to `Cargo.toml` to include optional logging dependencies (`pyo3-log` and `log`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R17-R19) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R31-R33).
* Updated `src/lib.rs` to conditionally use the `log` and `pyo3_log` crates for logging when the `logging` feature is enabled [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R9-R14) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R287-R298).
* Modified `src/dns.rs` to log errors using the `log` crate when the `logging` feature is enabled.

### Documentation and Examples:
* Updated the description in `README.md` to improve clarity and readability.
* Added a new example script `examples/logger.py` demonstrating how to use the `rnet` library with logging enabled.