### PR TITLE
feat: Added websocket optional config

### DIFF
--- a/rnet.pyi
+++ b/rnet.pyi
@@ -1168,10 +1168,16 @@ class WebSocketParams:
     """
     proxy: typing.Optional[builtins.str]
     interface: typing.Optional[builtins.str]
+    protocols: typing.Optional[builtins.list[builtins.str]]
     auth: typing.Optional[builtins.str]
     bearer_auth: typing.Optional[builtins.str]
     basic_auth: typing.Optional[tuple[builtins.str, typing.Optional[builtins.str]]]
     query: typing.Optional[builtins.list[tuple[builtins.str, builtins.str]]]
+    write_buffer_size: typing.Optional[builtins.int]
+    max_write_buffer_size: typing.Optional[builtins.int]
+    max_message_size: typing.Optional[builtins.int]
+    max_frame_size: typing.Optional[builtins.int]
+    accept_unmasked_frames: typing.Optional[builtins.bool]
 
 def delete(url:builtins.str, **kwds) -> typing.Any:
     r"""

--- a/src/client.rs
+++ b/src/client.rs
@@ -1001,6 +1001,13 @@ async fn execute_websocket_request(
     // The protocols to use for the request.
     apply_option!(apply_if_some, builder, params.protocols, protocols);
 
+    // The WebSocket config
+    apply_option!(apply_if_some, builder, params.write_buffer_size, write_buffer_size);
+    apply_option!(apply_if_some, builder, params.max_write_buffer_size, max_write_buffer_size);
+    apply_option!(apply_if_some, builder, params.max_frame_size, max_frame_size);
+    apply_option!(apply_if_some, builder, params.max_message_size, max_message_size);
+    apply_option!(apply_if_some, builder, params.accept_unmasked_frames, accept_unmasked_frames);
+
     // The origin to use for the request.
     builder = builder.with_builder(|mut builder| {
         // Network options.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1002,11 +1002,36 @@ async fn execute_websocket_request(
     apply_option!(apply_if_some, builder, params.protocols, protocols);
 
     // The WebSocket config
-    apply_option!(apply_if_some, builder, params.write_buffer_size, write_buffer_size);
-    apply_option!(apply_if_some, builder, params.max_write_buffer_size, max_write_buffer_size);
-    apply_option!(apply_if_some, builder, params.max_frame_size, max_frame_size);
-    apply_option!(apply_if_some, builder, params.max_message_size, max_message_size);
-    apply_option!(apply_if_some, builder, params.accept_unmasked_frames, accept_unmasked_frames);
+    apply_option!(
+        apply_if_some,
+        builder,
+        params.write_buffer_size,
+        write_buffer_size
+    );
+    apply_option!(
+        apply_if_some,
+        builder,
+        params.max_write_buffer_size,
+        max_write_buffer_size
+    );
+    apply_option!(
+        apply_if_some,
+        builder,
+        params.max_frame_size,
+        max_frame_size
+    );
+    apply_option!(
+        apply_if_some,
+        builder,
+        params.max_message_size,
+        max_message_size
+    );
+    apply_option!(
+        apply_if_some,
+        builder,
+        params.accept_unmasked_frames,
+        accept_unmasked_frames
+    );
 
     // The origin to use for the request.
     builder = builder.with_builder(|mut builder| {

--- a/src/param/websocket.rs
+++ b/src/param/websocket.rs
@@ -104,7 +104,7 @@ pub struct WebSocketParams {
     /// by a malicious user.
     #[pyo3(get)]
     pub max_frame_size: Option<usize>,
-    
+
     /// When set to `true`, the server will accept and handle unmasked frames
     /// from the client. According to the RFC 6455, the server must close the
     /// connection to the client in such cases, however it seems like there are

--- a/src/param/websocket.rs
+++ b/src/param/websocket.rs
@@ -49,6 +49,7 @@ pub struct WebSocketParams {
     pub headers: Option<IndexMap<String, String>>,
 
     /// The protocols to use for the request.
+    #[pyo3(get)]
     pub protocols: Option<Vec<String>>,
 
     /// The authentication to use for the request.
@@ -66,6 +67,51 @@ pub struct WebSocketParams {
     /// The query parameters to use for the request.
     #[pyo3(get)]
     pub query: Option<Vec<(String, String)>>,
+
+    /// The target minimum size of the write buffer to reach before writing the data
+    /// to the underlying stream.
+    /// The default value is 128 KiB.
+    ///
+    /// If set to `0` each message will be eagerly written to the underlying stream.
+    /// It is often more optimal to allow them to buffer a little, hence the default value.
+    ///
+    /// Note: [`flush`](WebSocket::flush) will always fully write the buffer regardless.
+    #[pyo3(get)]
+    pub write_buffer_size: Option<usize>,
+
+    /// The max size of the write buffer in bytes. Setting this can provide backpressure
+    /// in the case the write buffer is filling up due to write errors.
+    /// The default value is unlimited.
+    ///
+    /// Note: The write buffer only builds up past [`write_buffer_size`](Self::write_buffer_size)
+    /// when writes to the underlying stream are failing. So the **write buffer can not
+    /// fill up if you are not observing write errors even if not flushing**.
+    ///
+    /// Note: Should always be at least [`write_buffer_size + 1 message`](Self::write_buffer_size)
+    /// and probably a little more depending on error handling strategy.
+    #[pyo3(get)]
+    pub max_write_buffer_size: Option<usize>,
+
+    /// The maximum size of an incoming message. `None` means no size limit. The default value is 64 MiB
+    /// which should be reasonably big for all normal use-cases but small enough to prevent
+    /// memory eating by a malicious user.
+    #[pyo3(get)]
+    pub max_message_size: Option<usize>,
+
+    /// The maximum size of a single incoming message frame. `None` means no size limit. The limit is for
+    /// frame payload NOT including the frame header. The default value is 16 MiB which should
+    /// be reasonably big for all normal use-cases but small enough to prevent memory eating
+    /// by a malicious user.
+    #[pyo3(get)]
+    pub max_frame_size: Option<usize>,
+    
+    /// When set to `true`, the server will accept and handle unmasked frames
+    /// from the client. According to the RFC 6455, the server must close the
+    /// connection to the client in such cases, however it seems like there are
+    /// some popular libraries that are sending unmasked frames, ignoring the RFC.
+    /// By default this option is set to `false`, i.e. according to RFC 6455.
+    #[pyo3(get)]
+    pub accept_unmasked_frames: Option<bool>,
 }
 
 macro_rules! extract_option {
@@ -89,6 +135,12 @@ impl<'py> FromPyObject<'py> for WebSocketParams {
         extract_option!(ob, params, bearer_auth);
         extract_option!(ob, params, basic_auth);
         extract_option!(ob, params, query);
+
+        extract_option!(ob, params, write_buffer_size);
+        extract_option!(ob, params, max_write_buffer_size);
+        extract_option!(ob, params, max_message_size);
+        extract_option!(ob, params, max_frame_size);
+        extract_option!(ob, params, accept_unmasked_frames);
         Ok(params)
     }
 }


### PR DESCRIPTION
This pull request includes several enhancements to the WebSocket configuration in the `src/client.rs` and `src/param/websocket.rs` files. The changes focus on adding new configuration options for WebSocket parameters and ensuring they are properly applied during WebSocket requests.

### Enhancements to WebSocket configuration:

* Added new WebSocket configuration options to the `WebSocketParams` structure, including `write_buffer_size`, `max_write_buffer_size`, `max_message_size`, `max_frame_size`, and `accept_unmasked_frames`. These options provide more control over WebSocket behavior, such as buffer sizes and message handling.
* Updated the `FromPyObject` implementation for `WebSocketParams` to extract the new configuration options from Python objects. This ensures that the new parameters can be set from Python code.
* Modified the `execute_websocket_request` function in `src/client.rs` to apply the new WebSocket configuration options using the `apply_option!` macro. This change integrates the new parameters into the WebSocket request builder.
* Added the `#[pyo3(get)]` attribute to the new fields in `WebSocketParams` to expose them to Python code, allowing users to get and set these options from Python.