### PR TITLE
perf(http): Optimize the overhead of boundary checks for streaming types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ cookie = "0.18.0"
 arc-swap = "1.7.1"
 url = "2.5"
 rquest = { version = "2.1.5", features = ["full", "multipart", "websocket", "hickory-dns"] }
+bytes = "1"
 futures-util = { version = "0.3.0", default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/examples/stream.py
+++ b/examples/stream.py
@@ -12,10 +12,10 @@ async def main():
     print("Encoding: ", resp.encoding)
     print("Remote Address: ", resp.remote_addr)
 
-    streamer = resp.stream()
-    async for chunk in streamer:
-        print("Chunk: ", chunk)
-        await asyncio.sleep(0.1)
+    async with resp.stream() as streamer:
+        async for chunk in streamer:
+            print("Chunk: ", chunk)
+            await asyncio.sleep(0.1)
 
 
 if __name__ == "__main__":

--- a/rnet.pyi
+++ b/rnet.pyi
@@ -857,7 +857,7 @@ class Response:
 
     def stream(self) -> Streamer:
         r"""
-        Returns the stream content of the response.
+        Convert the response into a `Stream` of `Bytes` from the body.
         
         # Returns
         
@@ -947,7 +947,7 @@ class StatusCode:
 
 class Streamer:
     r"""
-    A streaming response.
+    A bytes streaming response.
     This is an asynchronous iterator that yields chunks of data from the response stream.
     This is used to stream the response content.
     This is used in the `stream` method of the `Response` class.
@@ -1004,6 +1004,12 @@ class Streamer:
         A `PyResult` containing an `Option<PyObject>`. If there is a next chunk, it returns `Some(PyObject)`.
         If the iterator is exhausted, it raises `PyStopAsyncIteration`.
         """
+        ...
+
+    def __aenter__(self) -> typing.Any:
+        ...
+
+    def __aexit__(self, _exc_type:typing.Any, _exc_value:typing.Any, _traceback:typing.Any) -> typing.Any:
         ...
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use arc_swap::{ArcSwap, Guard};
 use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use rquest::{
     header::{HeaderMap, HeaderName, HeaderValue},
@@ -134,10 +135,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::GET, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::GET, url, kwds))
     }
 
     /// Sends a POST request.
@@ -172,10 +170,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::POST, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::POST, url, kwds))
     }
 
     /// Sends a PUT request.
@@ -210,10 +205,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::PUT, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::PUT, url, kwds))
     }
 
     /// Sends a PATCH request.
@@ -248,10 +240,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::PATCH, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::PATCH, url, kwds))
     }
 
     /// Sends a DELETE request.
@@ -286,10 +275,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::DELETE, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::DELETE, url, kwds))
     }
 
     /// Sends a HEAD request.
@@ -324,10 +310,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::HEAD, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::HEAD, url, kwds))
     }
 
     /// Sends an OPTIONS request.
@@ -362,10 +345,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::OPTIONS, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::OPTIONS, url, kwds))
     }
 
     /// Sends a TRACE request.
@@ -400,10 +380,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(
-            py,
-            execute_request(client, Method::TRACE, url, kwds),
-        )
+        future_into_py(py, execute_request(client, Method::TRACE, url, kwds))
     }
 
     /// Sends a request with the given method and URL.
@@ -441,7 +418,7 @@ impl Client {
         kwds: Option<RequestParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(py, execute_request(client, method, url, kwds))
+        future_into_py(py, execute_request(client, method, url, kwds))
     }
 
     /// Sends a WebSocket request.
@@ -479,7 +456,7 @@ impl Client {
         kwds: Option<WebSocketParams>,
     ) -> PyResult<Bound<'rt, PyAny>> {
         let client = self.0.load();
-        pyo3_async_runtimes::tokio::future_into_py(py, execute_websocket_request(client, url, kwds))
+        future_into_py(py, execute_websocket_request(client, url, kwds))
     }
 }
 

--- a/src/response/http/stream.rs
+++ b/src/response/http/stream.rs
@@ -1,0 +1,140 @@
+use crate::error::wrap_rquest_error;
+use bytes::Bytes;
+use futures_util::{Stream, StreamExt};
+use pyo3::{exceptions::PyStopAsyncIteration, prelude::*, IntoPyObjectExt};
+use pyo3_async_runtimes::tokio::future_into_py;
+use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
+use std::{pin::Pin, sync::Arc};
+use tokio::sync::Mutex;
+
+/// A bytes streaming response.
+/// This is an asynchronous iterator that yields chunks of data from the response stream.
+/// This is used to stream the response content.
+/// This is used in the `stream` method of the `Response` class.
+/// This is used in an asynchronous for loop in Python.
+///
+/// # Examples
+///
+/// ```python
+/// import asyncio
+/// import rnet
+/// from rnet import Method, Impersonate
+///
+/// async def main():
+///     resp = await rnet.get("https://httpbin.org/stream/20")
+///     print("Status Code: ", resp.status_code)
+///     print("Version: ", resp.version)
+///     print("Response URL: ", resp.url)
+///     print("Headers: ", resp.headers.to_dict())
+///     print("Content-Length: ", resp.content_length)
+///     print("Encoding: ", resp.encoding)
+///     print("Remote Address: ", resp.remote_addr)
+///
+///     streamer = resp.stream()
+///     async for chunk in streamer:
+///         print("Chunk: ", chunk)
+///         await asyncio.sleep(0.1)
+///
+/// if __name__ == "__main__":
+///     asyncio.run(main())
+/// ```
+#[gen_stub_pyclass]
+#[pyclass]
+pub struct Streamer(
+    pub  Arc<
+        Mutex<
+            Option<
+                Pin<Box<dyn Stream<Item = Result<bytes::Bytes, rquest::Error>> + Send + 'static>>,
+            >,
+        >,
+    >,
+);
+
+impl Streamer {
+    /// Create a new `Streamer` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream` - A stream of bytes.
+    ///
+    /// # Returns
+    ///
+    /// A new `Streamer` instance.
+    pub fn new(
+        stream: impl Stream<Item = Result<Bytes, rquest::Error>> + Send + 'static,
+    ) -> Streamer {
+        Streamer(Arc::new(Mutex::new(Some(Box::pin(stream)))))
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl Streamer {
+    /// Returns the `Streamer` instance itself to be used as an asynchronous iterator.
+    ///
+    /// This method allows the `Streamer` to be used in an asynchronous for loop in Python.
+    ///
+    /// # Returns
+    ///
+    /// The `Streamer` instance itself.
+    #[inline(always)]
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Returns the next chunk of the response as an asynchronous iterator.
+    ///
+    /// This method implements the `__anext__` method for the `Streamer` class, allowing it to be
+    /// used as an asynchronous iterator in Python. It returns the next chunk of the response or
+    /// raises `PyStopAsyncIteration` if the iterator is exhausted.
+    ///
+    /// # Returns
+    ///
+    /// A `PyResult` containing an `Option<PyObject>`. If there is a next chunk, it returns `Some(PyObject)`.
+    /// If the iterator is exhausted, it raises `PyStopAsyncIteration`.
+    fn __anext__<'rt>(&self, py: Python<'rt>) -> PyResult<Option<Bound<'rt, PyAny>>> {
+        // Here we clone the inner field, so we can use it
+        // in our future.
+        let streamer = self.0.clone();
+        future_into_py(py, async move {
+            // Here we lock the mutex to access the data inside
+            // and call chunk() method to get the next value.
+            let val = streamer
+                .lock()
+                .await
+                .as_mut()
+                .ok_or_else(|| PyStopAsyncIteration::new_err("The iterator is exhausted"))?
+                .next()
+                .await;
+
+            match val {
+                Some(Ok(val)) => {
+                    // If we have a value, we return it as a PyObject.
+                    Python::with_gil(|py| Ok(Some(val.into_bound_py_any(py)?.unbind())))
+                }
+                Some(Err(err)) => Err(wrap_rquest_error(err)),
+                // Here we return PyStopAsyncIteration error,
+                // because python needs exceptions to tell that iterator
+                // has ended.
+                None => Err(PyStopAsyncIteration::new_err("The iterator is exhausted")),
+            }
+        })
+        .map(Some)
+    }
+
+    fn __aenter__<'a>(slf: PyRef<'a, Self>, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
+        let slf = slf.into_py_any(py)?;
+        future_into_py(py, async move { Ok(slf) })
+    }
+
+    fn __aexit__<'a>(
+        &'a mut self,
+        py: Python<'a>,
+        _exc_type: &Bound<'a, PyAny>,
+        _exc_value: &Bound<'a, PyAny>,
+        _traceback: &Bound<'a, PyAny>,
+    ) -> PyResult<Bound<'a, PyAny>> {
+        let streamer = self.0.clone();
+        future_into_py(py, async move { Ok(drop(streamer.lock().await.take())) })
+    }
+}

--- a/tests/resp_test.py
+++ b/tests/resp_test.py
@@ -79,6 +79,15 @@ async def test_get_bytes():
 
 
 @pytest.mark.asyncio
+async def test_get_stream():
+    url = "https://httpbin.org/stream/1"
+    response = await client.get(url)
+    async with response.stream() as streamer:
+        async for bytes in streamer:
+            assert bytes is not None
+
+
+@pytest.mark.asyncio
 async def test_peer_certificate():
     client = rnet.Client(tls_info=True)
     resp = await client.get("https://httpbin.org/anything")


### PR DESCRIPTION
This pull request includes several important changes to improve the handling of asynchronous streaming and simplify the codebase. The main changes involve updating the `Client` and `Response` classes, as well as renaming and refactoring files.

### Asynchronous Streaming Improvements:
* [`examples/stream.py`](diffhunk://#diff-11a1e7484ffc8ae4532af97bd17cb36187f2fa50fa68111c2d69984c980d2c8cL15-R15): Updated the `main` function to use an asynchronous context manager for streaming.
* [`rnet.pyi`](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eR1009-R1014): Added `__aenter__` and `__aexit__` methods to the `Streamer` class to support asynchronous context management.

### Codebase Simplification:
* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L137-R138): Simplified the `Client` implementation by removing redundant calls to `pyo3_async_runtimes::tokio::future_into_py` and replacing them with `future_into_py`. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L137-R138) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L175-R173) [[3]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L213-R208) [[4]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L251-R243) [[5]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L289-R278) [[6]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L327-R313) [[7]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L365-R348) [[8]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L403-R383) [[9]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L444-R421) [[10]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L482-R459)
* [`src/response/http/mod.rs`](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0R1-L13): Renamed from `src/response/http.rs` and refactored to remove the `Streamer` class definition, moving it to a separate `stream` module. Updated the `Response` class methods to use `future_into_py` for asynchronous operations. [[1]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0R1-L13) [[2]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L200-R206) [[3]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L220-R224) [[4]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L234-R238) [[5]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L246-R250) [[6]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L259-R263) [[7]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L272-R290) [[8]](diffhunk://#diff-26e3eb2ba29919cbf429372628b21908d5c6ff479a0f3becbbedbcf948452ea0L339-L427)

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R43): Added the `bytes` dependency.

### Import Adjustments:
* [`src/client.rs`](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R14): Added import for `pyo3_async_runtimes::tokio::future_into_py`.…sponse types