### PR TITLE
build: Minimum required Python version is 3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pyo3 = { version = "0.23.0", features = [
     "anyhow",
     "indexmap",
     "multiple-pymethods",
-    "abi3-py39",
+    "abi3-py37",
     "generate-import-lib",
     "experimental-inspect",
 ] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,13 @@ build-backend = "maturin"
 
 [project]
 name = "rnet"
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This pull request includes changes to expand the compatibility of the project to older Python versions and adjust the dependencies accordingly.

Compatibility updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R26): Changed the `abi3` feature from `py39` to `py37` to support Python 3.7 and above.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R13): Updated the `requires-python` field to `>=3.7` and added classifiers for Python 3.7 and 3.8.