### PR TITLE
feat(client): Optional DNS lookup ip strategy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ use pyo3::prelude::*;
 use pyo3_log::{Caching, Logger};
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use types::{
-    HeaderMap, Impersonate, ImpersonateOS, Method, Multipart, Part, Proxy, SocketAddr, StatusCode,
-    Version,
+    HeaderMap, Impersonate, ImpersonateOS, LookupIpStrategy, Method, Multipart, Part, Proxy,
+    SocketAddr, StatusCode, Version,
 };
 
 #[cfg(not(target_env = "msvc"))]
@@ -310,6 +310,7 @@ fn rnet(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ImpersonateOS>()?;
     m.add_class::<SocketAddr>()?;
     m.add_class::<Proxy>()?;
+    m.add_class::<LookupIpStrategy>()?;
     m.add_class::<ClientParams>()?;
     m.add_class::<UpdateClientParams>()?;
     m.add_class::<RequestParams>()?;

--- a/src/param/client.rs
+++ b/src/param/client.rs
@@ -1,4 +1,4 @@
-use crate::types::{Impersonate, ImpersonateOS, Proxy};
+use crate::types::{Impersonate, ImpersonateOS, LookupIpStrategy, Proxy};
 use indexmap::IndexMap;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::gen_stub_pyclass;
@@ -80,6 +80,10 @@ pub struct ClientParams {
     /// Whether to use cookie store.
     #[pyo3(get)]
     pub cookie_store: Option<bool>,
+
+    /// The lookup ip strategy
+    #[pyo3(get)]
+    pub lookup_ip_strategy: Option<LookupIpStrategy>,
 
     // ========= Timeout options =========
     /// The timeout to use for the request. (in seconds)
@@ -260,6 +264,7 @@ impl<'py> FromPyObject<'py> for ClientParams {
         extract_option!(ob, params, referer);
         extract_option!(ob, params, allow_redirects);
         extract_option!(ob, params, cookie_store);
+        extract_option!(ob, params, lookup_ip_strategy);
 
         extract_option!(ob, params, timeout);
         extract_option!(ob, params, connect_timeout);

--- a/src/types/dns.rs
+++ b/src/types/dns.rs
@@ -1,0 +1,14 @@
+use crate::define_enum_with_conversion;
+use pyo3::prelude::*;
+use pyo3_stub_gen::derive::gen_stub_pyclass_enum;
+
+define_enum_with_conversion!(
+    const,
+    /// The lookup ip strategy.
+    LookupIpStrategy, rquest::dns::LookupIpStrategy,
+    Ipv4Only,
+    Ipv6Only,
+    Ipv4AndIpv6,
+    Ipv6thenIpv4,
+    Ipv4thenIpv6,
+);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+mod dns;
 mod headers;
 mod impersonate;
 mod ipaddr;
@@ -9,6 +10,7 @@ mod status;
 mod version;
 
 pub use self::{
+    dns::LookupIpStrategy,
     headers::HeaderMap,
     impersonate::{Impersonate, ImpersonateOS},
     ipaddr::SocketAddr,


### PR DESCRIPTION
This pull request introduces several changes to the `rnet.pyi` and Rust files to add support for a new `LookupIpStrategy` enumeration and improve DNS resolver configuration. The most important changes include adding the `LookupIpStrategy` enum, updating the `ClientParams` and `Client` structures to use this new strategy, and modifying the DNS resolver initialization to accommodate the new strategy.

### New Feature: LookupIpStrategy Support

* Added `LookupIpStrategy` enum to specify different IP lookup strategies, including `Ipv4Only`, `Ipv6Only`, `Ipv4AndIpv6`, `Ipv6thenIpv4`, and `Ipv4thenIpv6`. (`rnet.pyi`, `src/types/dns.rs`, `src/types/mod.rs`) [[1]](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eR1228-R1237) [[2]](diffhunk://#diff-7be0378b4680ba283c497dedeaa7fd54358d6072cde3fae4d412ba360f717680R1-R14) [[3]](diffhunk://#diff-44bee847315d06d50bad561b0284381c81b52274429ff45ccec047d25f8ce45dR1) [[4]](diffhunk://#diff-44bee847315d06d50bad561b0284381c81b52274429ff45ccec047d25f8ce45dR13)

### Client Parameters Update

* Updated the `ClientParams` class to include the `lookup_ip_strategy` attribute. (`rnet.pyi`, `src/param/client.rs`) [[1]](diffhunk://#diff-5db1607ce9c6dc00847ecf786751d151324bea51f62f7baf42b71b20603dbf4eR421) [[2]](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R84-R87) [[3]](diffhunk://#diff-ad245d448ef30d353626c3c90a1d5058b600666084be5cd25b43a6f9911f2e11R267)

### DNS Resolver Initialization

* Modified the DNS resolver initialization function to accept and handle the new `LookupIpStrategy` parameter. (`src/dns.rs`) [[1]](diffhunk://#diff-59889a794dcd5497d370e57f0ff9c047cba4738d11974377dc610c6b063011ebL1-R12) [[2]](diffhunk://#diff-59889a794dcd5497d370e57f0ff9c047cba4738d11974377dc610c6b063011ebL17-R44)

### Rust Client Implementation

* Updated the `Client` struct to use the new `LookupIpStrategy` for DNS resolver configuration. (`src/client/mod.rs`) [[1]](diffhunk://#diff-1b84118fef4e05f6f4c73c9ad3c5d469ec065f0ef62e20448683dadf6f281c6dL13-R13) [[2]](diffhunk://#diff-1b84118fef4e05f6f4c73c9ad3c5d469ec065f0ef62e20448683dadf6f281c6dL61-R66) [[3]](diffhunk://#diff-1b84118fef4e05f6f4c73c9ad3c5d469ec065f0ef62e20448683dadf6f281c6dL543-R553)

### WebSocket Example Update

* Updated the WebSocket example to use the `Message` class for sending text messages. (`rnet.pyi`)