### PR TITLE
feat: allow inheritance of Client and BlockingClient in python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,24 +4,26 @@ build-backend = "maturin"
 
 [project]
 name = "rnet"
-requires-python = ">=3.9"
+requires-python = ">=3.7"
 classifiers = [
-  "Programming Language :: Rust",
-  "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-  "Development Status :: 5 - Production/Stable",
-  "Intended Audience :: Developers",
-  "Topic :: Software Development :: Libraries :: Python Modules",
-  'Operating System :: Microsoft :: Windows',
-  'Operating System :: POSIX',
-  'Operating System :: Unix',
-  'Operating System :: MacOS',
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    'Operating System :: Microsoft :: Windows',
+    'Operating System :: POSIX',
+    'Operating System :: Unix',
+    'Operating System :: MacOS',
 ]
 description = "A blazing-fast Python HTTP client with TLS fingerprint"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,34 +4,30 @@ build-backend = "maturin"
 
 [project]
 name = "rnet"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: POSIX',
-    'Operating System :: Unix',
-    'Operating System :: MacOS',
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  'Operating System :: Microsoft :: Windows',
+  'Operating System :: POSIX',
+  'Operating System :: Unix',
+  'Operating System :: MacOS',
 ]
 description = "A blazing-fast Python HTTP client with TLS fingerprint"
 readme = "README.md"
 dynamic = ["version"]
 license = { text = "GPL-3.0" }
-authors = [
-    { name = "0x676e67", email = "gngppz@gmail.com" }
-]
+authors = [{ name = "0x676e67", email = "gngppz@gmail.com" }]
 keywords = ["http", "client", "websocket", "ja3", "ja4"]
 
 [tool.maturin]
@@ -43,7 +39,5 @@ Documentation = "https://github.com/0x676e67/rnet/blob/main/rnet.pyi"
 Homepage = "https://github.com/0x676e67/rnet"
 Repository = "https://github.com/0x676e67/rnet"
 
-[tool.poetry.dev-dependencies]
-pytest = "^8.3.4"
-pytest-asyncio = "^0.25.3"
-pytest-rerunfailures = "^15.0"
+[dependency-groups]
+dev = ["pytest>=8.3.4", "pytest-asyncio>=0.25.3", "pytest-rerunfailures>=15.0"]

--- a/rnet.pyi
+++ b/rnet.pyi
@@ -2058,6 +2058,7 @@ class Impersonate(Enum):
     SafariIPad18 = auto()
     Safari18_2 = auto()
     Safari18_3 = auto()
+    Safari18_3_1 = auto()
     SafariIos18_1_1 = auto()
     OkHttp3_9 = auto()
     OkHttp3_11 = auto()

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -17,6 +17,7 @@ use std::{net::IpAddr, ops::Deref};
 /// A client for making HTTP requests.
 #[gen_stub_pyclass]
 #[pyclass]
+#[pyo3(subclass)]
 pub struct Client(rquest::Client);
 
 impl Deref for Client {

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -16,8 +16,7 @@ use std::{net::IpAddr, ops::Deref};
 
 /// A client for making HTTP requests.
 #[gen_stub_pyclass]
-#[pyclass]
-#[pyo3(subclass)]
+#[pyclass(subclass)]
 pub struct Client(rquest::Client);
 
 impl Deref for Client {

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -10,6 +10,7 @@ use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 /// A blocking client for making HTTP requests.
 #[gen_stub_pyclass]
 #[pyclass]
+#[pyo3(subclass)]
 pub struct BlockingClient(async_impl::Client);
 
 macro_rules! define_http_method {

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -9,8 +9,7 @@ use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
 /// A blocking client for making HTTP requests.
 #[gen_stub_pyclass]
-#[pyclass]
-#[pyo3(subclass)]
+#[pyclass(subclass)]
 pub struct BlockingClient(async_impl::Client);
 
 macro_rules! define_http_method {

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,6 +1,33 @@
 import pytest
 import rnet
-from rnet import Impersonate, ImpersonateOS, Cookie
+from rnet import Cookie, Impersonate, ImpersonateOS
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=1, reruns_delay=2)
+async def test_inherit_client():
+    class SubClient(rnet.Client):
+        def __init__(self, **kwargs):
+            self.test_var = "test"
+            self.cookie_jar = None
+
+    client = SubClient(impersonate=Impersonate.Chrome133)
+    url = "https://google.com"
+    response = await client.get(url)
+    text = await response.text()
+    assert text is not None
+    assert client.cookie_jar is None
+    assert client.test_var == "test"
+    client.update(
+        impersonate=Impersonate.Firefox135,
+        impersonate_os=ImpersonateOS.Windows,
+        Impersonate_skip_headers=False,
+    )
+    assert (
+        client.user_agent
+        == "Mozilla/5.0 (Windows NT 10.0; rv:135.0) Gecko/20100101 Firefox/135.0"
+    )
+    assert client.test_var == "test"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allowing inheritance of the `Client` and `BlockingClient` class enables customization on user-level which is not necessary to add in the `rnet` module.