### PR TITLE
chore(error): refactor exception error handling

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -1,8 +1,8 @@
 use crate::apply_option;
+use crate::error::Error;
 use crate::{
     Result,
     async_impl::{Response, WebSocket},
-    error::wrap_rquest_error,
     typing::param::{RequestParams, WebSocketParams},
     typing::{Method, Version},
 };
@@ -130,7 +130,8 @@ where
         .send()
         .await
         .map(Response::new)
-        .map_err(wrap_rquest_error)
+        .map_err(Error::RquestError)
+        .map_err(Into::into)
 }
 
 /// Executes a WebSocket request.
@@ -250,5 +251,8 @@ where
     // Query options.
     apply_option!(apply_if_some_ref, builder, params.query, query);
 
-    WebSocket::new(builder).await.map_err(wrap_rquest_error)
+    WebSocket::new(builder)
+        .await
+        .map_err(Error::RquestError)
+        .map_err(Into::into)
 }

--- a/src/async_impl/response/ws/message.rs
+++ b/src/async_impl/response/ws/message.rs
@@ -8,7 +8,7 @@ use rquest::Utf8Bytes;
 
 use crate::{
     buffer::{BytesBuffer, PyBufferProtocol},
-    error::wrap_rquest_error,
+    error::Error,
     typing::Json,
 };
 
@@ -27,7 +27,12 @@ impl Message {
     ///
     /// A `PyResult` containing the JSON representation of the message.
     pub fn json(&self, py: Python) -> PyResult<Json> {
-        py.allow_threads(|| self.0.json::<Json>().map_err(wrap_rquest_error))
+        py.allow_threads(|| {
+            self.0
+                .json::<Json>()
+                .map_err(Error::RquestError)
+                .map_err(Into::into)
+        })
     }
 
     /// Returns the data of the message as bytes.
@@ -136,7 +141,8 @@ impl Message {
         py.allow_threads(|| {
             rquest::Message::text_from_json(&json)
                 .map(Message)
-                .map_err(wrap_rquest_error)
+                .map_err(Error::RquestError)
+                .map_err(Into::into)
         })
     }
 
@@ -155,7 +161,8 @@ impl Message {
         py.allow_threads(|| {
             rquest::Message::binary_from_json(&json)
                 .map(Message)
-                .map_err(wrap_rquest_error)
+                .map_err(Error::RquestError)
+                .map_err(Into::into)
         })
     }
 

--- a/src/blocking/response/ws.rs
+++ b/src/blocking/response/ws.rs
@@ -1,6 +1,6 @@
 use crate::{
     async_impl::{self, Message},
-    error::py_stop_iteration_error,
+    error::Error,
     typing::{Cookie, HeaderMap, SocketAddr, StatusCode, Version},
 };
 use pyo3::{prelude::*, pybacked::PyBackedStr};
@@ -187,10 +187,10 @@ impl BlockingWebSocket {
     #[inline(always)]
     fn __next__(&self, py: Python) -> PyResult<Message> {
         py.allow_threads(|| {
-            pyo3_async_runtimes::tokio::get_runtime().block_on(async_impl::WebSocket::_anext(
-                self.receiver(),
-                py_stop_iteration_error,
-            ))
+            pyo3_async_runtimes::tokio::get_runtime()
+                .block_on(async_impl::WebSocket::_anext(self.receiver(), || {
+                    Error::StopIteration.into()
+                }))
         })
     }
 

--- a/src/typing/cookie.rs
+++ b/src/typing/cookie.rs
@@ -1,4 +1,3 @@
-use crate::error::wrap_invali_header_value_error;
 use bytes::Bytes;
 use pyo3::FromPyObject;
 use pyo3::pybacked::PyBackedStr;
@@ -8,6 +7,8 @@ use pyo3_stub_gen::{PyStubType, TypeInfo};
 use rquest::cookie::{self, Expiration};
 use rquest::header::{self, HeaderMap, HeaderValue};
 use std::time::SystemTime;
+
+use crate::error::Error;
 
 /// A cookie.
 #[gen_stub_pyclass]
@@ -193,7 +194,8 @@ impl FromPyObject<'_> for CookieFromPyDict {
             .and_then(|cookies| {
                 HeaderValue::from_maybe_shared(Bytes::from(cookies))
                     .map(Self)
-                    .map_err(wrap_invali_header_value_error)
+                    .map_err(Error::InvalidHeaderValue)
+                    .map_err(Into::into)
             })
     }
 }

--- a/src/typing/headers.rs
+++ b/src/typing/headers.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::{HeaderNameBuffer, HeaderValueBuffer, PyBufferProtocol},
-    error::{wrap_invali_header_name_error, wrap_invali_header_value_error},
+    error::Error,
 };
 use pyo3::{
     prelude::*,
@@ -149,11 +149,11 @@ impl FromPyObject<'_> for HeaderMapFromPyDict {
                 header::HeaderMap::with_capacity(dict.len()),
                 |mut headers, (key, value)| {
                     let key = key.extract::<PyBackedStr>()?;
-                    let name = HeaderName::from_bytes(key.as_bytes())
-                        .map_err(wrap_invali_header_name_error)?;
+                    let name =
+                        HeaderName::from_bytes(key.as_bytes()).map_err(Error::InvalidHeaderName)?;
                     let value = value.extract::<PyBackedStr>()?;
                     let value = HeaderValue::from_bytes(value.as_bytes())
-                        .map_err(wrap_invali_header_value_error)?;
+                        .map_err(Error::InvalidHeaderValue)?;
                     headers.insert(name, value);
                     Ok(headers)
                 },
@@ -186,7 +186,7 @@ impl<'py> FromPyObject<'py> for HeadersOrderFromPyList {
         list.iter()
             .try_fold(Vec::with_capacity(list.len()), |mut order, item| {
                 let name = HeaderName::from_str(item.extract::<&str>()?)
-                    .map_err(wrap_invali_header_name_error)?;
+                    .map_err(Error::InvalidHeaderName)?;
                 order.push(name);
                 Ok(order)
             })

--- a/src/typing/multipart/form.rs
+++ b/src/typing/multipart/form.rs
@@ -1,5 +1,5 @@
 use super::part::Part;
-use crate::error::memory_error;
+use crate::error::Error;
 use pyo3::{prelude::*, types::PyTuple};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use rquest::multipart::Form;
@@ -25,7 +25,7 @@ impl Multipart {
                 .take()
                 .zip(part.inner.take())
                 .map(|(name, inner)| new_form.part(name, inner))
-                .ok_or_else(memory_error)?;
+                .ok_or_else(|| Error::MemoryError)?;
         }
         Ok(Multipart(Some(new_form)))
     }

--- a/src/typing/multipart/part.rs
+++ b/src/typing/multipart/part.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{MIMEParseError, wrap_io_error},
+    error::{Error, MIMEParseError},
     stream::{AsyncStream, SyncStream},
 };
 use bytes::Bytes;
@@ -57,7 +57,7 @@ impl Part {
                 }
                 PartData::File(path) => pyo3_async_runtimes::tokio::get_runtime()
                     .block_on(rquest::multipart::Part::file(path))
-                    .map_err(wrap_io_error)?,
+                    .map_err(Error::IoError)?,
                 PartData::SyncStream(stream) => {
                     rquest::multipart::Part::stream(rquest::Body::wrap_stream(stream))
                 }

--- a/src/typing/proxy.rs
+++ b/src/typing/proxy.rs
@@ -1,5 +1,6 @@
+use crate::error::Error;
+
 use super::HeaderMapFromPyDict;
-use crate::error::wrap_rquest_error;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use rquest::header::HeaderValue;
@@ -180,7 +181,7 @@ impl Proxy {
         custom_httt_headers: Option<HeaderMapFromPyDict>,
         exclusion: Option<&'a str>,
     ) -> PyResult<Self> {
-        let mut proxy = proxy_fn(url).map_err(wrap_rquest_error)?;
+        let mut proxy = proxy_fn(url).map_err(Error::RquestError)?;
         // Convert the username and password to a basic auth header value.
         if let (Some(username), Some(password)) = (username, password) {
             proxy = proxy.basic_auth(username, password)


### PR DESCRIPTION
This pull request focuses on refactoring error handling throughout the codebase by consolidating various error types into a single `Error` type. The changes involve updating error handling in multiple files and functions to use this new consolidated error type.

### Error Handling Refactor:

* [`src/async_impl/client.rs`](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L6-R10): Replaced specific error handling functions like `wrap_rquest_error` and `wrap_url_parse_error` with the consolidated `Error` type. [[1]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L6-R10) [[2]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L594-R596) [[3]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L638-R644) [[4]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L712-R718) [[5]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L740-R746) [[6]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L762-R768) [[7]](diffhunk://#diff-0df5342f97493f9f55d6f43a14268f327ea9e791c7fdb8df6d88ec81f6baa721L860-R869)
* [`src/async_impl/request.rs`](diffhunk://#diff-07c00ed0a60a9b6e356e3d045f6932d4872c8d474abb755c6785c9292a076266R2-L5): Updated error handling in request functions to use the `Error::RquestError` type. [[1]](diffhunk://#diff-07c00ed0a60a9b6e356e3d045f6932d4872c8d474abb755c6785c9292a076266R2-L5) [[2]](diffhunk://#diff-07c00ed0a60a9b6e356e3d045f6932d4872c8d474abb755c6785c9292a076266L133-R134) [[3]](diffhunk://#diff-07c00ed0a60a9b6e356e3d045f6932d4872c8d474abb755c6785c9292a076266L253-R257)
* [`src/async_impl/response/http.rs`](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L3-R3): Modified response handling to replace specific error functions with the `Error` type. [[1]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L3-R3) [[2]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L72-R73) [[3]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L226-R236) [[4]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L250-R254) [[5]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L262-R269) [[6]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L278-R285) [[7]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L386-R403) [[8]](diffhunk://#diff-06ab3e081cbfc8f6b2eea48685b0301ecb3949483a508f3e0c12590c3b078002L418-R421)
* [`src/async_impl/response/ws/message.rs`](diffhunk://#diff-bd922e14fecfa3791e5a8b7debae18b59bc1be39cc6e957dc74c52460da0ce8aL11-R11): Refactored WebSocket message handling to use the new `Error` type for error handling. [[1]](diffhunk://#diff-bd922e14fecfa3791e5a8b7debae18b59bc1be39cc6e957dc74c52460da0ce8aL11-R11) [[2]](diffhunk://#diff-bd922e14fecfa3791e5a8b7debae18b59bc1be39cc6e957dc74c52460da0ce8aL30-R35) [[3]](diffhunk://#diff-bd922e14fecfa3791e5a8b7debae18b59bc1be39cc6e957dc74c52460da0ce8aL139-R145) [[4]](diffhunk://#diff-bd922e14fecfa3791e5a8b7debae18b59bc1be39cc6e957dc74c52460da0ce8aL158-R165)
* [`src/async_impl/response/ws/mod.rs`](diffhunk://#diff-810b69fd22cbba39013496deb66d149cac234227b79f648b778ed3ef2361c524L4-R4): Updated WebSocket module to use the consolidated `Error` type for various error scenarios. [[1]](diffhunk://#diff-810b69fd22cbba39013496deb66d149cac234227b79f648b778ed3ef2361c524L4-R4) [[2]](diffhunk://#diff-810b69fd22cbba39013496deb66d149cac234227b79f648b778ed3ef2361c524L75-R90) [[3]](diffhunk://#diff-810b69fd22cbba39013496deb66d149cac234227b79f648b778ed3ef2361c524L119-R123) [[4]](diffhunk://#diff-810b69fd22cbba39013496deb66d149cac234227b79f648b778ed3ef2361c524L141-R143) [[5]](diffhunk://#diff-810b69fd22cbba39013496deb66d149cac234227b79f648b778ed3ef2361c524L308-R310)
* [`src/blocking/response/http.rs`](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL6-R6): Changed blocking response handling to use the `Error::RquestError` type. [[1]](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL6-R6) [[2]](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL167-R168) [[3]](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL185-R187) [[4]](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL199-R202) [[5]](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL214-R217) [[6]](diffhunk://#diff-f778f4156e8a7710d5244a0cceeb38d2c739a9d9bf2c805e00afd9e9b866645bL277-R283)
* [`src/blocking/response/ws.rs`](diffhunk://#diff-e3e73798b83d4a3ff1f8ce2ac492ba60513c8797f662ff7b3f71ce465a9754e2L3-R3): Refactored blocking WebSocket response handling to use the new `Error` type.