### PR TITLE
docs(json): Improve `Json` type hints

### DIFF
--- a/src/typing/json.rs
+++ b/src/typing/json.rs
@@ -17,6 +17,6 @@ pub enum Json {
 
 impl PyStubType for Json {
     fn type_output() -> TypeInfo {
-        TypeInfo::any()
+        TypeInfo::with_module("typing.Dict[str, typing.Any]", "typing".into())
     }
 }


### PR DESCRIPTION
This pull request includes a change to the `Json` enum in the `src/typing/json.rs` file. The change updates the return value of the `type_output` method to use a more specific type representation.

* [`src/typing/json.rs`](diffhunk://#diff-ca3c654de0fbfb9d5c05141294e7b9d5d50041350008bfaf4fe060d1560fedebL20-R20): Modified the `type_output` method to return `TypeInfo::with_module("typing.Dict[str, typing.Any]", "typing".into())` instead of `TypeInfo::any()`.