### PR TITLE
docs(status): Improve StatusCode `__repr__` implement

### DIFF
--- a/rnet.pyi
+++ b/rnet.pyi
@@ -649,7 +649,7 @@ class BlockingResponse:
         """
         ...
 
-    def json(self) -> typing.Any:
+    def json(self) -> typing.Dict[str, typing.Any]:
         r"""
         Returns the JSON content of the response.
         
@@ -1472,7 +1472,7 @@ class Message:
         ...
 
     @staticmethod
-    def text_from_json(json:typing.Any) -> Message:
+    def text_from_json(json:typing.Dict[str, typing.Any]) -> Message:
         r"""
         Creates a new text message from the JSON representation.
         
@@ -1486,7 +1486,7 @@ class Message:
         ...
 
     @staticmethod
-    def binary_from_json(json:typing.Any) -> Message:
+    def binary_from_json(json:typing.Dict[str, typing.Any]) -> Message:
         r"""
         Creates a new binary message from the JSON representation.
         
@@ -1575,7 +1575,7 @@ class Message:
         """
         ...
 
-    def json(self) -> typing.Any:
+    def json(self) -> typing.Dict[str, typing.Any]:
         r"""
         Returns the JSON representation of the message.
         

--- a/src/typing/json.rs
+++ b/src/typing/json.rs
@@ -17,6 +17,6 @@ pub enum Json {
 
 impl PyStubType for Json {
     fn type_output() -> TypeInfo {
-        TypeInfo::any()
+        TypeInfo::with_module("typing.Dict[str, typing.Any]", "typing".into())
     }
 }

--- a/src/typing/status.rs
+++ b/src/typing/status.rs
@@ -56,8 +56,8 @@ impl StatusCode {
     }
 
     #[inline(always)]
-    fn __repr__(&self) -> String {
-        format!("StatusCode({})", self.0)
+    fn __repr__(&self) -> &str {
+        self.__str__()
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve type annotations and refactor code for better readability and maintainability. The most important changes include updating type annotations for JSON-related methods and modifying the `__repr__` method for the `StatusCode` implementation.

Code refactoring:

* [`src/typing/status.rs`](diffhunk://#diff-2e249aaa933bd6f06dcd1669446f61c21740a93696b5ca5325ca2f5c3092ea0cL59-R60): Refactored the `__repr__` method in the `StatusCode` implementation to return the result of the `__str__` method.