### PR TITLE
feat(client): http1 headers uppercase conversion by default

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -357,6 +357,9 @@ impl Client {
             apply_option!(apply_if_some, builder, params.zstd, zstd);
 
             builder
+                .http1(|mut http1| {
+                    http1.title_case_headers(true);
+                })
                 .build()
                 .map(Client)
                 .map_err(Error::RquestError)


### PR DESCRIPTION
from: https://github.com/0x676e67/rnet/issues/191

This follows the browser style. Of course, it cannot solve all problems, but it can solve most of the AWF blocking problems.