### PR TITLE
refactor(async_impl): Use async style for `Response.close()` to match async conventions

### DIFF
--- a/rnet.pyi
+++ b/rnet.pyi
@@ -2048,7 +2048,7 @@ class Response:
         Convert the response into a `Stream` of `Bytes` from the body.
         """
 
-    def close(self) -> None:
+    async def close(self) -> None:
         r"""
         Closes the response connection.
         """

--- a/src/async_impl/response/http.rs
+++ b/src/async_impl/response/http.rs
@@ -197,9 +197,10 @@ impl Response {
     }
 
     /// Closes the response connection.
-    pub fn close(&self, py: Python) -> PyResult<()> {
-        py.allow_threads(|| {
-            let _ = self.inner().map(drop);
+    pub fn close<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let res = py.allow_threads(|| self.inner());
+        future_into_py(py, async move {
+            let _ = res.map(drop);
             Ok(())
         })
     }
@@ -213,14 +214,13 @@ impl Response {
     }
 
     fn __aexit__<'py>(
-        &self,
+        &'py self,
         py: Python<'py>,
         _exc_type: &Bound<'py, PyAny>,
         _exc_value: &Bound<'py, PyAny>,
         _traceback: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let res = self.close(py);
-        future_into_py(py, async move { res })
+        self.close(py)
     }
 }
 

--- a/src/async_impl/response/http.rs
+++ b/src/async_impl/response/http.rs
@@ -198,7 +198,7 @@ impl Response {
 
     /// Closes the response connection.
     pub fn close<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let res = py.allow_threads(|| self.inner());
+        let res = self.inner();
         future_into_py(py, async move {
             let _ = res.map(drop);
             Ok(())


### PR DESCRIPTION
close: https://github.com/0x676e67/rnet/issues/203