### PR TITLE
build(jemallocator): exclude dependency on Linux GNU targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,8 @@ wreq = { version = "5.1.0", features = [
 ] }
 wreq-util = { version = "2.2.2", features = ["emulation-rand"]}
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(all(not(target_env = "msvc"), not(all(target_os = "linux", target_env = "gnu"))) )'.dependencies]
 jemallocator = { package = "tikv-jemallocator", version = "0.6", features = [
     "disable_initial_exec_tls",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-
-[profile.release]
-lto = true
-opt-level = 3
-codegen-units = 1
-strip = true
-panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,10 @@ jemallocator = { package = "tikv-jemallocator", version = "0.6", features = [
     "disable_initial_exec_tls",
     "unprefixed_malloc_on_supported_platforms",
 ] }
+
+[profile.release]
+lto = "fat"
+opt-level = 3
+codegen-units = 1
+strip = true
+panic = "abort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,10 @@ use typing::{
     SocketAddr, StatusCode, TlsVersion, Version,
 };
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(
+    not(target_env = "msvc"),
+    not(all(target_os = "linux", target_env = "gnu"))
+))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
from: https://github.com/0x676e67/rnet/issues/222

According to the user-supplied test machine, Linux GNU, the result is: Essentially, this is an ABI explosion triggered by Linux ELF TLS model conflicts + dynamic load rule restrictions + compiler behavior union.