### PR TITLE
refactor(response): remove `encoding` readonly property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ pyo3-async-runtimes = { version = "0.25.0", features = [
 ] }
 pin-project-lite = "0.2.16"
 serde = { version = "1.0.219", features = ["derive"] }
-mime = "0.3.17"
 indexmap = { version = "2.10.0", features = ["serde"] }
 bytes = "1.10.1"
 futures-util = { version = "0.3.31", default-features = false }

--- a/python/rnet/__init__.pyi
+++ b/python/rnet/__init__.pyi
@@ -545,11 +545,6 @@ class Response:
     Get the local address of the response.
     """
 
-    encoding: str
-    r"""
-    Get encoding to decode with when accessing text.
-    """
-
     def history(self) -> List[History]:
         r"""
         Get the redirect history of the Response.

--- a/python/rnet/blocking.py
+++ b/python/rnet/blocking.py
@@ -365,11 +365,6 @@ class Response:
     Get the local address of the response.
     """
 
-    encoding: str
-    r"""
-    Get encoding to decode with when accessing text.
-    """
-
     def history(self) -> List[History]:
         r"""
         Get the redirect history of the Response.

--- a/src/client/response/http.rs
+++ b/src/client/response/http.rs
@@ -1,8 +1,7 @@
 use futures_util::TryFutureExt;
 use http::{Extensions, response::Response as HttpResponse};
-use mime::Mime;
 use pyo3::{IntoPyObjectExt, prelude::*, pybacked::PyBackedStr};
-use wreq::{self, ResponseBuilderExt, Uri, header, tls::TlsInfo};
+use wreq::{self, ResponseBuilderExt, Uri, tls::TlsInfo};
 
 use super::Streamer;
 use crate::{
@@ -150,23 +149,6 @@ impl Response {
     #[getter]
     pub fn cookies(&self) -> Vec<Cookie> {
         Cookie::extract_headers_cookies(&self.headers.0)
-    }
-
-    /// Encoding to decode with when accessing text.
-    #[getter]
-    pub fn encoding(&self, py: Python) -> String {
-        py.allow_threads(|| {
-            self.headers
-                .0
-                .get(header::CONTENT_TYPE)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|value| value.parse::<Mime>().ok())
-                .and_then(|mime| {
-                    mime.get_param("charset")
-                        .map(|charset| charset.as_str().to_owned())
-                })
-                .unwrap_or_else(|| "utf-8".to_owned())
-        })
     }
 
     /// Get the redirect history of the Response.
@@ -330,12 +312,6 @@ impl BlockingResponse {
     #[getter]
     pub fn history(&self, py: Python) -> Vec<History> {
         self.0.history(py)
-    }
-
-    /// Get encoding to decode with when accessing text.
-    #[getter]
-    pub fn encoding(&self, py: Python) -> String {
-        self.0.encoding(py)
     }
 
     /// Get the TLS peer certificate of the response.


### PR DESCRIPTION
The encoding readonly property is generally not very useful, since the `response.text()` method already provides automatic decoding. If you need to specify a particular string decoding, you can still use the `text_with_charset()` method.