### PR TITLE
feat(client): enforce proper usage of custom cookie provider

### DIFF
--- a/python/rnet/__init__.pyi
+++ b/python/rnet/__init__.pyi
@@ -529,12 +529,12 @@ class ClientConfig(TypedDict):
 
     cookie_store: NotRequired[bool]
     """
-    Enable cookie store.
+    Enable internal cookie store provider.
     """
 
     cookie_provider: NotRequired[Jar]
     """
-    Custom cookie provider.
+    Custom cookie store provider.
     """
 
     # ========= Timeout options ========

--- a/src/client.rs
+++ b/src/client.rs
@@ -274,13 +274,13 @@ impl Client {
                 apply_option!(set_if_some_inner, builder, config.redirect, redirect);
 
                 // Cookie options.
+                apply_option!(set_if_some, builder, config.cookie_store, cookie_store);
                 apply_option!(
                     set_if_some_inner,
                     builder,
                     config.cookie_provider,
                     cookie_provider
                 );
-                apply_option!(set_if_some, builder, config.cookie_store, cookie_store);
 
                 // TCP options.
                 apply_option!(set_if_some, builder, config.tcp_keepalive, tcp_keepalive);


### PR DESCRIPTION
from: https://github.com/0x676e67/rnet/issues/462

When both a cookie store and a cookie provider are configured, the cookie provider will take precedence over the built-in provider set by the cookie store, reducing the chance of unintentional user mistakes.