### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2F0x676e67%2Frnet%2Fmain%2Fpyproject.toml&logo=python)
 [![PyPI](https://img.shields.io/pypi/v/rnet?logo=python)](https://pypi.org/project/rnet/)
 [![PyPI Downloads](https://static.pepy.tech/badge/rnet)](https://pepy.tech/projects/rnet)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/0x676e67/rnet)
 
 > 🚀 Help me work seamlessly with open source sharing by [sponsoring me on GitHub](https://github.com/0x676e67/0x676e67/blob/main/SPONSOR.md)
 


### PR DESCRIPTION
## Summary
- add the DeepWiki badge to the README

## Why
DeepWiki showed this guidance after refresh:
"Refresh started! We'll email you when the refresh completes. Want auto-refresh? Add a badge in the repo's README."

This change adds the badge so future DeepWiki refreshes can run automatically.