### PR TITLE
fix(headers): OrigHeaderMap constructor drops header casing

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -288,11 +288,8 @@ impl OrigHeaderMap {
         // and we want to prevent Python's garbage collector from managing it.
         if let Some(init) = init {
             for name in init.iter() {
-                let name = match name
-                    .extract::<PyBackedStr>()
-                    .map(|n| HeaderName::from_bytes(n.as_bytes()))
-                {
-                    Ok(Ok(n)) => n,
+                let name = match name.extract::<PyBackedStr>() {
+                    Ok(n) => Bytes::from_owner(n),
                     _ => continue,
                 };
 


### PR DESCRIPTION
# Fix: OrigHeaderMap constructor drops header casing

## Problem

`OrigHeaderMap(list)` does not preserve the casing of header names passed to it.

For example:
```python
OrigHeaderMap(['Host', 'User-Agent', 'Accept'])
```
sends `host`, `user-agent`, `accept` on the wire — all lowercase — despite the title-case input.

## Root cause

In `src/header.rs`, the `new()` constructor converts each string to a `HeaderName` via
`HeaderName::from_bytes()` before inserting it into the map:

```rust
let name = match name
    .extract::<PyBackedStr>()
    .map(|n| HeaderName::from_bytes(n.as_bytes()))  // normalises to lowercase
{
    Ok(Ok(n)) => n,
    _ => continue,
};
headers.insert(name);  // inserts as Kind::Standard → lowercase on wire
```

`HeaderName` is always stored lowercase (per the HTTP spec's normalisation). When inserted
into `OrigHeaderMap`, it becomes `Kind::Standard`, whose `as_ref()` returns the lowercase
canonical form — so the original casing is permanently lost.

By contrast, the `insert()` method and the `FromPyObject` impl both use `Bytes::from_owner()`
which goes through `Kind::Cased`, preserving the exact bytes as given.

## Fix

Change `new()` to use the same `Bytes` path as `insert()` and `FromPyObject`:

```rust
let name = match name.extract::<PyBackedStr>() {
    Ok(n) => Bytes::from_owner(n),
    _ => continue,
};
headers.insert(name);  // inserts as Kind::Cased → exact casing preserved on wire
```

## Impact

Any code that constructs `OrigHeaderMap` via the constructor (e.g. `OrigHeaderMap(['Host', 'X-Custom'])`)
now correctly preserves the supplied casing. The `insert()` method was already correct and is unaffected.
