### PR TITLE
ci: replace maturin upload step with uv publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [manylinux, musllinux, windows, macos, android, sdist, tests, style]
     permissions:
       # Use to sign the release artifacts
@@ -386,19 +385,21 @@ jobs:
       attestations: write
     steps:
       - uses: actions/download-artifact@v8
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v7
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: "wheels-*/*"
+      - name: Dry-run publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --dry-run wheels-*/*
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          maturin-version: ${{ env.MATURIN_VERSION }}
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish wheels-*/*
       - name: Upload binaries to GitHub Release
         uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
close: https://github.com/0x676e67/wreq-python/issues/572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation pipeline with improved publishing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->