### PR TITLE
fix(tls): register KeyShare class in Python module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use pyo3::{
 use tikv_jemallocator as _;
 use tls::{
     AlpnProtocol, AlpsProtocol, CertStore, CertificateCompressionAlgorithm, ExtensionType,
-    Identity, KeyLog, TlsInfo, TlsOptions, TlsVersion,
+    Identity, KeyLog, KeyShare, TlsInfo, TlsOptions, TlsVersion,
 };
 
 #[cfg(all(feature = "jemalloc", feature = "mimalloc"))]
@@ -445,6 +445,7 @@ fn tls_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<KeyLog>()?;
     m.add_class::<AlpnProtocol>()?;
     m.add_class::<AlpsProtocol>()?;
+    m.add_class::<KeyShare>()?;
     m.add_class::<CertificateCompressionAlgorithm>()?;
     m.add_class::<ExtensionType>()?;
     m.add_class::<TlsOptions>()?;


### PR DESCRIPTION
## Problem

`from wreq.tls import KeyShare` fails:

```python
>>> from wreq.tls import KeyShare
ImportError: cannot import name 'KeyShare' from 'tls' (unknown location)
```

As a consequence, `TlsOptions(key_shares=[...])` cannot be constructed,
since the pyo3 extractor strictly checks `isinstance(x, KeyShare)`:

```python
>>> from wreq.tls import TlsOptions
>>> TlsOptions(key_shares=[1])
TypeError: argument 'kwds': 'int' object is not an instance of 'KeyShare'
```

`KeyShare` is part of the documented public API
(https://python.wreq.org/en/latest/api/tls/#KeyShare) and is the
declared element type of `TlsOptions(key_shares: Sequence[KeyShare])`.

## Root cause

`KeyShare` is defined in `src/tls.rs` via `define_enum!` and consumed by
`TlsOptions::Builder.key_shares: Option<Vec<KeyShare>>`, but it is never
imported into `src/lib.rs` and never registered with
`m.add_class::<KeyShare>()?` in `tls_module`. The other five enums
defined by `define_enum!` in `src/tls.rs` (`TlsVersion`, `AlpnProtocol`,
`AlpsProtocol`, `CertificateCompressionAlgorithm`, `ExtensionType`) are
all registered correctly.

## Fix

Add `KeyShare` to the `tls::` import list and register it alongside the
other TLS enums:

```rust
 use tls::{
     AlpnProtocol, AlpsProtocol, CertStore, CertificateCompressionAlgorithm, ExtensionType,
-    Identity, KeyLog, TlsInfo, TlsOptions, TlsVersion,
+    Identity, KeyLog, KeyShare, TlsInfo, TlsOptions, TlsVersion,
 };
 ...
     m.add_class::<AlpsProtocol>()?;
+    m.add_class::<KeyShare>()?;
     m.add_class::<CertificateCompressionAlgorithm>()?;
```

After the fix:

```python
>>> from wreq.tls import TlsOptions, KeyShare
>>> TlsOptions(key_shares=[KeyShare.X25519, KeyShare.X25519_MLKEM768])
<wreq.tls.TlsOptions object at ...>
```

Happy to adjust the approach or split this differently if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KeyShare is now available in the TLS wrapper, enabling additional cryptographic key exchange capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->