### PR TITLE
feat(client): implement `raise_for_status` for Client

### DIFF
--- a/python/wreq/wreq.py
+++ b/python/wreq/wreq.py
@@ -536,6 +536,11 @@ class ClientConfig(TypedDict):
     Set a `redirect.Policy` for this client.
     """
 
+    raise_for_status: NotRequired[bool]
+    """
+    Enable or disable automatic raising of exceptions for HTTP status codes.
+    """
+
     cookie_store: NotRequired[bool]
     """
     Enable a persistent cookie store for the client.
@@ -861,6 +866,11 @@ class Request(TypedDict):
     redirect: NotRequired[redirect.Policy]
     """
     The redirect policy.
+    """
+
+    raise_for_status: NotRequired[bool]
+    """
+    Raise for status.
     """
 
     cookie_provider: NotRequired[Jar]

--- a/python/wreq/wreq.py
+++ b/python/wreq/wreq.py
@@ -868,11 +868,6 @@ class Request(TypedDict):
     The redirect policy.
     """
 
-    raise_for_status: NotRequired[bool]
-    """
-    Raise for status.
-    """
-
     cookie_provider: NotRequired[Jar]
     """
     Set cookie provider for the request.

--- a/src/client.rs
+++ b/src/client.rs
@@ -235,11 +235,11 @@ impl FromPyObject<'_, '_> for Builder {
 pub struct Client {
     inner: wreq::Client,
     cancel: CancellationToken,
+    raise_for_status: bool,
 
     /// Get the cookie jar of the client.
     #[pyo3(get)]
     cookie_jar: Option<Jar>,
-    raise_for_status: bool,
 }
 
 /// A blocking client for making HTTP requests.
@@ -585,7 +585,7 @@ impl Client {
         kwds: Option<Request>,
     ) -> PyResult<Response> {
         NoGIL::new_with_token(
-            execute_request(self.inner.clone(), method, url, kwds, self.raise_for_status),
+            execute_request(self.clone(), method, url, kwds),
             cancel,
             self.cancel.clone(),
         )
@@ -602,7 +602,7 @@ impl Client {
         kwds: Option<WebSocketRequest>,
     ) -> PyResult<WebSocket> {
         NoGIL::new_with_token(
-            execute_websocket_request(self.inner.clone(), url, kwds),
+            execute_websocket_request(self.clone(), url, kwds),
             cancel,
             self.cancel.clone(),
         )
@@ -755,13 +755,7 @@ impl BlockingClient {
     ) -> PyResult<BlockingResponse> {
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime()
-                .block_on(execute_request(
-                    self.0.inner.clone(),
-                    method,
-                    url,
-                    kwds,
-                    self.0.raise_for_status,
-                ))
+                .block_on(execute_request(self.0.clone(), method, url, kwds))
                 .map(Into::into)
         })
     }
@@ -776,7 +770,7 @@ impl BlockingClient {
     ) -> PyResult<BlockingWebSocket> {
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime()
-                .block_on(execute_websocket_request(self.0.inner.clone(), url, kwds))
+                .block_on(execute_websocket_request(self.0.clone(), url, kwds))
                 .map(Into::into)
         })
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -72,6 +72,8 @@ struct Builder {
     referer: Option<bool>,
     /// Whether to redirect policy.
     redirect: Option<redirect::Policy>,
+    /// Whether to raise for status.
+    raise_for_status: Option<bool>,
 
     // ========= Cookie options =========
     /// Whether to use cookie store.
@@ -176,6 +178,7 @@ impl FromPyObject<'_, '_> for Builder {
         extract_option!(ob, builder, orig_headers);
         extract_option!(ob, builder, referer);
         extract_option!(ob, builder, redirect);
+        extract_option!(ob, builder, raise_for_status);
 
         extract_option!(ob, builder, cookie_store);
         extract_option!(ob, builder, cookie_provider);
@@ -236,6 +239,7 @@ pub struct Client {
     /// Get the cookie jar of the client.
     #[pyo3(get)]
     cookie_jar: Option<Jar>,
+    raise_for_status: bool,
 }
 
 /// A blocking client for making HTTP requests.
@@ -255,6 +259,7 @@ impl Client {
             // Create the client builder.
             let mut builder = wreq::Client::builder();
             let mut cookie_jar: Option<Jar> = None;
+            let mut raise_for_status = false;
 
             if let Some(mut config) = kwds {
                 // Emulation options.
@@ -450,6 +455,8 @@ impl Client {
                 apply_option!(set_if_some, builder, config.brotli, brotli);
                 apply_option!(set_if_some, builder, config.deflate, deflate);
                 apply_option!(set_if_some, builder, config.zstd, zstd);
+
+                raise_for_status = config.raise_for_status.unwrap_or(false);
             }
 
             builder
@@ -458,6 +465,7 @@ impl Client {
                     inner,
                     cancel: CancellationToken::new(),
                     cookie_jar,
+                    raise_for_status,
                 })
                 .map_err(Error::Library)
                 .map_err(Into::into)
@@ -577,7 +585,7 @@ impl Client {
         kwds: Option<Request>,
     ) -> PyResult<Response> {
         NoGIL::new_with_token(
-            execute_request(self.inner.clone(), method, url, kwds),
+            execute_request(self.inner.clone(), method, url, kwds, self.raise_for_status),
             cancel,
             self.cancel.clone(),
         )
@@ -747,7 +755,13 @@ impl BlockingClient {
     ) -> PyResult<BlockingResponse> {
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime()
-                .block_on(execute_request(self.0.inner.clone(), method, url, kwds))
+                .block_on(execute_request(
+                    self.0.inner.clone(),
+                    method,
+                    url,
+                    kwds,
+                    self.0.raise_for_status,
+                ))
                 .map(Into::into)
         })
     }

--- a/src/client/req.rs
+++ b/src/client/req.rs
@@ -6,10 +6,10 @@ use std::{
 use futures_util::TryFutureExt;
 use http::header::COOKIE;
 use pyo3::{PyResult, prelude::*, pybacked::PyBackedStr};
-use wreq::Client;
 
 use crate::{
     client::{
+        Client,
         body::{Body, Form, Json, multipart::Multipart},
         query::Query,
         resp::{Response, WebSocket},
@@ -293,13 +293,12 @@ pub async fn execute_request<U>(
     method: Method,
     url: U,
     request: Option<Request>,
-    mut raise_for_status: bool,
 ) -> PyResult<Response>
 where
     U: AsRef<str>,
 {
     // Create the request builder.
-    let mut builder = client.request(method.into_ffi(), url.as_ref());
+    let mut builder = client.inner.request(method.into_ffi(), url.as_ref());
 
     if let Some(mut request) = request {
         // Emulation options.
@@ -386,11 +385,6 @@ where
         // Allow redirects options.
         apply_option!(set_if_some_inner, builder, request.redirect, redirect);
 
-        // Allow raise for status options.
-        if let Some(value) = request.raise_for_status.take() {
-            raise_for_status = value;
-        }
-
         // Compression options.
         apply_option!(set_if_some, builder, request.gzip, gzip);
         apply_option!(set_if_some, builder, request.brotli, brotli);
@@ -419,13 +413,17 @@ where
     }
 
     // Send request.
-    let resp = builder.send().await;
-    let resp = if raise_for_status {
-        resp.and_then(|r| r.error_for_status())
-    } else {
-        resp
-    };
-    resp.map(Response::new)
+    builder
+        .send()
+        .await
+        .and_then(|r| {
+            if client.raise_for_status {
+                r.error_for_status()
+            } else {
+                Ok(r)
+            }
+        })
+        .map(Response::new)
         .map_err(Error::Library)
         .map_err(Into::into)
 }
@@ -439,7 +437,7 @@ where
     U: AsRef<str>,
 {
     // Create the WebSocket builder.
-    let mut builder = client.websocket(url.as_ref());
+    let mut builder = client.inner.websocket(url.as_ref());
 
     if let Some(mut request) = request {
         // Emulation options.

--- a/src/client/req.rs
+++ b/src/client/req.rs
@@ -67,9 +67,6 @@ pub struct Request {
     /// The redirect policy to use for the request.
     redirect: Option<redirect::Policy>,
 
-    /// The option enables raise for status.
-    raise_for_status: Option<bool>,
-
     /// The cookie provider to use for the request.
     cookie_provider: Option<Jar>,
 
@@ -234,7 +231,6 @@ impl FromPyObject<'_, '_> for Request {
         extract_option!(ob, request, default_headers);
         extract_option!(ob, request, cookies);
         extract_option!(ob, request, redirect);
-        extract_option!(ob, request, raise_for_status);
         extract_option!(ob, request, cookie_provider);
         extract_option!(ob, request, auth);
         extract_option!(ob, request, bearer_auth);

--- a/src/client/req.rs
+++ b/src/client/req.rs
@@ -67,6 +67,9 @@ pub struct Request {
     /// The redirect policy to use for the request.
     redirect: Option<redirect::Policy>,
 
+    /// The option enables raise for status.
+    raise_for_status: Option<bool>,
+
     /// The cookie provider to use for the request.
     cookie_provider: Option<Jar>,
 
@@ -231,6 +234,7 @@ impl FromPyObject<'_, '_> for Request {
         extract_option!(ob, request, default_headers);
         extract_option!(ob, request, cookies);
         extract_option!(ob, request, redirect);
+        extract_option!(ob, request, raise_for_status);
         extract_option!(ob, request, cookie_provider);
         extract_option!(ob, request, auth);
         extract_option!(ob, request, bearer_auth);
@@ -289,6 +293,7 @@ pub async fn execute_request<U>(
     method: Method,
     url: U,
     request: Option<Request>,
+    mut raise_for_status: bool,
 ) -> PyResult<Response>
 where
     U: AsRef<str>,
@@ -381,6 +386,11 @@ where
         // Allow redirects options.
         apply_option!(set_if_some_inner, builder, request.redirect, redirect);
 
+        // Allow raise for status options.
+        if let Some(value) = request.raise_for_status.take() {
+            raise_for_status = value;
+        }
+
         // Compression options.
         apply_option!(set_if_some, builder, request.gzip, gzip);
         apply_option!(set_if_some, builder, request.brotli, brotli);
@@ -409,10 +419,13 @@ where
     }
 
     // Send request.
-    builder
-        .send()
-        .await
-        .map(Response::new)
+    let resp = builder.send().await;
+    let resp = if raise_for_status {
+        resp.and_then(|r| r.error_for_status())
+    } else {
+        resp
+    };
+    resp.map(Response::new)
         .map_err(Error::Library)
         .map_err(Into::into)
 }


### PR DESCRIPTION
Fix #581 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional client-level setting to control whether HTTP error status codes automatically raise exceptions.
  * Applies to both regular HTTP and WebSocket request flows; default behavior is unchanged when unset.
  * Setting is documented for client configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->