### PR TITLE
feat(dns): optional system DNS resolver

### DIFF
--- a/python/wreq/dns.py
+++ b/python/wreq/dns.py
@@ -46,7 +46,7 @@ class DnsOptions:
     Example:
         >>> from wreq import DnsOptions, LookupIpStrategy
         >>> from ipaddress import IPv4Address
-        >>> options = DnsOptions(LookupIpStrategy.Ipv4Only)
+        >>> options = DnsOptions(LookupIpStrategy.IPV4_ONLY)
         >>> options.add_resolve("example.com", [IPv4Address("127.0.0.1")])
     """
 

--- a/python/wreq/dns.py
+++ b/python/wreq/dns.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address, IPv6Address
 
 __all__ = [
     "LookupIpStrategy",
-    "ResolverOptions",
+    "DnsOptions",
 ]
 
 
@@ -33,27 +33,35 @@ class LookupIpStrategy(Enum):
     """Prefer IPv4, fall back to IPv6."""
 
 
-class ResolverOptions:
-    """DNS resolver options for customizing DNS resolution behavior.
+class DnsOptions:
+    """DNS options for customizing DNS resolution behavior.
 
     Args:
-        lookup_ip_strategy: The IP lookup strategy to use. Defaults to IPV4_AND_IPV6.
+        system_dns: Whether to use the system DNS resolver. Defaults to False,
+            which means using the hickory DNS resolver.
+        lookup_ip_strategy: The IP lookup strategy to use. Defaults to
+            IPV4_AND_IPV6. This option only applies to the hickory DNS
+            resolver and has no effect when using the system DNS resolver.
 
     Example:
-        >>> from wreq import ResolverOptions, LookupIpStrategy
+        >>> from wreq import DnsOptions, LookupIpStrategy
         >>> from ipaddress import IPv4Address
-        >>> options = ResolverOptions(LookupIpStrategy.Ipv4Only)
+        >>> options = DnsOptions(LookupIpStrategy.Ipv4Only)
         >>> options.add_resolve("example.com", [IPv4Address("127.0.0.1")])
     """
 
     def __init__(
         self,
+        system_dns: bool = False,
         lookup_ip_strategy: LookupIpStrategy = LookupIpStrategy.IPV4_AND_IPV6,
     ) -> None:
-        """Create a new ResolverOptions with the given lookup IP strategy.
+        """Create a new DnsOptions.
 
         Args:
-            lookup_ip_strategy: The IP lookup strategy to use.
+            system_dns: Whether to use the system DNS resolver. When False,
+                the hickory DNS resolver is used.
+            lookup_ip_strategy: The IP lookup strategy to use. Only effective
+                when using the hickory DNS resolver.
         """
         ...
 
@@ -72,7 +80,7 @@ class ResolverOptions:
 
         Example:
             >>> from ipaddress import IPv4Address, IPv6Address
-            >>> options = ResolverOptions()
+            >>> options = DnsOptions()
             >>> options.add_resolve("api.example.com", [IPv4Address("192.168.1.1")])
             >>> options.add_resolve("cdn.example.com", [
             ...     IPv6Address("2001:db8::1"),

--- a/python/wreq/wreq.py
+++ b/python/wreq/wreq.py
@@ -19,7 +19,7 @@ from typing import (
 from . import redirect
 from . import emulation
 from .cookie import *
-from .dns import ResolverOptions
+from .dns import DnsOptions
 from .emulation import *
 from .header import *
 from .http1 import Http1Options
@@ -759,7 +759,7 @@ class ClientConfig(TypedDict):
 
     # ========= DNS options =========
 
-    dns_options: NotRequired[ResolverOptions]
+    dns_options: NotRequired[DnsOptions]
 
     # ========= Compression options =========
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -19,7 +19,7 @@ use std::os::raw::c_int;
 
 use bytes::Bytes;
 use pyo3::{ffi, prelude::*};
-use wreq::header::{HeaderName, HeaderValue, OrigHeaderName};
+use wreq::header::{HeaderCaseName, HeaderName, HeaderValue};
 
 /// [`PyBuffer`] enables zero-copy conversion of Rust [`Bytes`] to Python bytes.
 pub struct PyBuffer(BufferView);
@@ -72,8 +72,8 @@ impl From<HeaderName> for PyBuffer {
     }
 }
 
-impl From<OrigHeaderName> for PyBuffer {
-    fn from(value: OrigHeaderName) -> Self {
+impl From<HeaderCaseName> for PyBuffer {
+    fn from(value: HeaderCaseName) -> Self {
         Self::from(Bytes::from_owner(value))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,6 @@ mod query;
 
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::Arc,
     time::Duration,
 };
 
@@ -24,7 +23,7 @@ use self::{
 };
 use crate::{
     cookie::Jar,
-    dns::{HickoryDnsResolver, LookupIpStrategy, ResolverOptions},
+    dns::{DnsOptions, HickoryResolver, LookupIpStrategy},
     emulate::EmulationLike,
     error::Error,
     extractor::Extractor,
@@ -154,7 +153,7 @@ struct Builder {
     interface: Option<String>,
 
     // ========= DNS options =========
-    dns_options: Option<ResolverOptions>,
+    dns_options: Option<DnsOptions>,
 
     // ========= Compression options =========
     /// Sets gzip as an accepted encoding.
@@ -438,16 +437,18 @@ impl Client {
                 apply_option!(set_if_some, builder, config.interface, interface);
 
                 // DNS options.
-                builder = {
-                    let dns_resolver = if let Some(options) = config.dns_options.take() {
-                        for (domain, addrs) in options.resolve_to_addrs {
-                            builder = builder.resolve_to_addrs(domain.as_ref().to_string(), addrs);
-                        }
-                        HickoryDnsResolver::new(options.lookup_ip_strategy)
-                    } else {
-                        HickoryDnsResolver::new(LookupIpStrategy::default())
-                    };
-                    builder.dns_resolver(Arc::new(dns_resolver))
+                if let Some(opts) = config.dns_options.take() {
+                    for (domain, addrs) in opts.resolve_to_addrs {
+                        builder = builder.resolve_to_addrs(domain.as_ref().to_string(), addrs);
+                    }
+
+                    if !opts.system_dns {
+                        builder =
+                            builder.dns_resolver(HickoryResolver::new(opts.lookup_ip_strategy));
+                    }
+                } else {
+                    builder =
+                        builder.dns_resolver(HickoryResolver::new(LookupIpStrategy::default()));
                 };
 
                 // Compression options.

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -34,18 +34,24 @@ impl Default for LookupIpStrategy {
 /// DNS resolver options for customizing DNS resolution behavior.
 #[derive(Clone)]
 #[pyclass(from_py_object)]
-pub struct ResolverOptions {
+pub struct DnsOptions {
+    pub system_dns: bool,
     pub lookup_ip_strategy: LookupIpStrategy,
     pub resolve_to_addrs: Vec<(Arc<PyBackedStr>, Vec<SocketAddr>)>,
 }
 
 #[pymethods]
-impl ResolverOptions {
-    /// Create a new [`ResolverOptions`] with the given lookup ip strategy.
+impl DnsOptions {
+    /// Create a new [`DnsOptions`].
+    ///
+    /// When `system_dns` is `false`, hickory is used as the DNS resolver.
+    /// `lookup_ip_strategy` only applies to hickory and has no effect when
+    /// using the system DNS resolver.
     #[new]
-    #[pyo3(signature=(lookup_ip_strategy = LookupIpStrategy::IPV4_AND_IPV6))]
-    pub fn new(lookup_ip_strategy: LookupIpStrategy) -> Self {
-        ResolverOptions {
+    #[pyo3(signature=(system_dns = false, lookup_ip_strategy = LookupIpStrategy::IPV4_AND_IPV6))]
+    pub fn new(system_dns: bool, lookup_ip_strategy: LookupIpStrategy) -> Self {
+        DnsOptions {
+            system_dns,
             lookup_ip_strategy,
             resolve_to_addrs: Vec::new(),
         }
@@ -70,17 +76,17 @@ static RESOLVER_IPV4_THEN_IPV6: OnceLock<TokioResolver> = OnceLock::new();
 
 /// Wrapper around an [`TokioResolver`], which implements the `Resolve` trait.
 #[derive(Clone)]
-pub struct HickoryDnsResolver {
+pub struct HickoryResolver {
     /// Shared, lazily-initialized Tokio-based DNS resolver.
     resolver: &'static TokioResolver,
 }
 
-impl HickoryDnsResolver {
+impl HickoryResolver {
     /// Create a new resolver with the default configuration,
     /// which reads from `/etc/resolve.conf`. The options are
     /// overriden to look up for both IPv4 and IPv6 addresses
     /// to work with "happy eyeballs" algorithm.
-    pub fn new(strategy: LookupIpStrategy) -> HickoryDnsResolver {
+    pub fn new(strategy: LookupIpStrategy) -> HickoryResolver {
         let cell = match strategy {
             LookupIpStrategy::IPV4_ONLY => &RESOLVER_IPV4_ONLY,
             LookupIpStrategy::IPV6_ONLY => &RESOLVER_IPV6_ONLY,
@@ -89,7 +95,7 @@ impl HickoryDnsResolver {
             LookupIpStrategy::IPV4_THEN_IPV6 => &RESOLVER_IPV4_THEN_IPV6,
         };
 
-        HickoryDnsResolver {
+        HickoryResolver {
             resolver: cell.get_or_init(move || {
                 let mut builder = match TokioResolver::builder_tokio() {
                     Ok(resolver) => resolver,
@@ -112,7 +118,7 @@ struct SocketAddrs {
     iter: LookupIpIntoIter,
 }
 
-impl Resolve for HickoryDnsResolver {
+impl Resolve for HickoryResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let resolver = self.clone();
         Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use client::{
     resp::{BlockingResponse, BlockingWebSocket, Message, Response, WebSocket},
 };
 use cookie::{Cookie, Jar, SameSite};
-use dns::{LookupIpStrategy, ResolverOptions};
+use dns::{DnsOptions, LookupIpStrategy};
 use emulate::{Emulation, Platform, Profile};
 use error::*;
 use header::{HeaderMap, OrigHeaderMap};
@@ -413,7 +413,7 @@ fn proxy_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[pymodule(gil_used = false, name = "dns")]
 fn dns_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LookupIpStrategy>()?;
-    m.add_class::<ResolverOptions>()?;
+    m.add_class::<DnsOptions>()?;
     Ok(())
 }
 

--- a/tests/dns_test.py
+++ b/tests/dns_test.py
@@ -2,13 +2,13 @@ from ipaddress import IPv4Address
 import pytest
 from wreq import Client
 from wreq.exceptions import ConnectionError
-from wreq.dns import ResolverOptions, LookupIpStrategy
+from wreq.dns import DnsOptions, LookupIpStrategy
 
 
 @pytest.mark.asyncio
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 async def test_dns_resolve_override():
-    dns_options = ResolverOptions(lookup_ip_strategy=LookupIpStrategy.IPV4_ONLY)
+    dns_options = DnsOptions(lookup_ip_strategy=LookupIpStrategy.IPV4_ONLY)
     dns_options.add_resolve("www.google.com", [IPv4Address("192.168.1.1")])
     client = Client(
         dns_options=dns_options,


### PR DESCRIPTION
This is a breaking change: rename `ResolverOptions` to `DnsOptions`